### PR TITLE
Fix build 'clang-tidy'

### DIFF
--- a/.clang-tidy.in
+++ b/.clang-tidy.in
@@ -36,6 +36,7 @@ Checks: "*,\
 -fuchsia-default-arguments,\
 -hicpp-vararg,\
 -clang-analyzer-optin.cplusplus.VirtualCall,\
+-clang-analyzer-optin.core.EnumCastOutOfRange,\
 -cppcoreguidelines-owning-memory,\
 -hicpp-no-array-decay,\
 -*-magic-numbers,\
@@ -70,6 +71,7 @@ Checks: "*,\
 -google-readability-avoid-underscore-in-googletest-name,\
 -readability-function-cognitive-complexity,\
 -readability-avoid-const-params-in-decls,\
+-readability-avoid-return-with-void-value,\
 -cppcoreguidelines-avoid-const-or-ref-data-members,\
 -cppcoreguidelines-avoid-do-while,\
 -altera-struct-pack-align,\

--- a/.clang-tidy.in
+++ b/.clang-tidy.in
@@ -83,7 +83,6 @@ Checks: "*,\
 -bugprone-switch-missing-default-case"
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^${RELATIVE_SOURCE_DIR}(base|modules|test)/'
-AnalyzeTemporaryDtors: false
 UseColor: true
 User:            root
 CheckOptions:

--- a/exe/backend/src/http_server.cc
+++ b/exe/backend/src/http_server.cc
@@ -247,6 +247,7 @@ struct http_server::impl {
     cb(json_response(req, gj.string()));
   }
 
+  // NOLINTBEGIN(readability-avoid-return-with-void-value)
   void handle_request(web_server::http_req_t const& req,
                       web_server::http_res_cb_t const& cb) {
     std::cout << "[" << req.method_string() << "] " << req.target() << '\n';
@@ -343,6 +344,7 @@ struct http_server::impl {
     }
     server_.run();
   }
+  // NOLINTEND(readability-avoid-return-with-void-value)
 
   void stop() { server_.stop(); }
 

--- a/exe/backend/src/http_server.cc
+++ b/exe/backend/src/http_server.cc
@@ -247,7 +247,6 @@ struct http_server::impl {
     cb(json_response(req, gj.string()));
   }
 
-  // NOLINTBEGIN(readability-avoid-return-with-void-value)
   void handle_request(web_server::http_req_t const& req,
                       web_server::http_res_cb_t const& cb) {
     std::cout << "[" << req.method_string() << "] " << req.target() << '\n';
@@ -344,7 +343,6 @@ struct http_server::impl {
     }
     server_.run();
   }
-  // NOLINTEND(readability-avoid-return-with-void-value)
 
   void stop() { server_.stop(); }
 

--- a/include/osr/lookup.h
+++ b/include/osr/lookup.h
@@ -77,6 +77,37 @@ struct lookup {
     return cista::mmap{(p_ / file).generic_string().c_str(), mode_};
   }
 
+  match_t get_raw_match(location const& query,
+                        double const max_match_distance) {
+    auto way_candidates = std::vector<way_candidate>{};
+    find(geo::box{query.pos_, max_match_distance}, [&](way_idx_t const way) {
+      auto d = geo::distance_to_polyline<way_candidate>(
+          query.pos_, ways_.way_polylines_[way]);
+      if (d.dist_to_way_ < max_match_distance) {
+        d.way_ = way;
+        way_candidates.emplace_back(d);
+      }
+    });
+    utl::sort(way_candidates);
+    return way_candidates;
+  }
+
+  template <typename Profile>
+  match_t complete_match(match_t match,
+                         bool reverse,
+                         direction const search_dir,
+                         bitvec<node_idx_t>& blocked) {
+    for (auto& wc : match) {
+      wc.left_ =
+          find_next_node<Profile>(wc, wc.query_, direction::kBackward,
+                                  wc.query_.lvl_, reverse, search_dir, blocked);
+      wc.right_ =
+          find_next_node<Profile>(wc, wc.query_, direction::kForward,
+                                  wc.query_.lvl_, reverse, search_dir, blocked);
+    }
+    return match;
+  }
+
   match_t match(location const& query,
                 bool const reverse,
                 direction const search_dir,
@@ -128,7 +159,6 @@ private:
           query.pos_, ways_.way_polylines_[way]);
       if (d.dist_to_way_ < max_match_distance) {
         auto& wc = way_candidates.emplace_back(std::move(d));
-        wc.query_ = query;
         wc.way_ = way;
         wc.left_ =
             find_next_node<Profile>(wc, query, direction::kBackward, query.lvl_,

--- a/include/osr/routing/profiles/bike.h
+++ b/include/osr/routing/profiles/bike.h
@@ -35,7 +35,7 @@ struct bike {
   using key = node;
 
   struct label {
-    label(node const n, cost_t const c) : n_{n.n_}, cost_{c} {}
+    label(node const n, cost_t const c) : n_{n.n_}, lvl_{}, cost_{c} {}
 
     constexpr node get_node() const noexcept { return {n_}; }
     constexpr cost_t cost() const noexcept { return cost_; }

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -42,6 +42,7 @@ using namespace std::string_view_literals;
 
 namespace osr {
 
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 struct osm_restriction {
   bool valid() const {
     return from_ != osm_way_idx_t::invalid() &&
@@ -525,6 +526,7 @@ void extract(bool const with_platforms,
               return buf;
             }) &
             oneapi::tbb::make_filter<osm_mem::Buffer, void>(
+                // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
                 oneapi::tbb::filter_mode::parallel, [&](osm_mem::Buffer&& buf) {
                   update_locations(node_idx, buf);
                   osm::apply(buf, h);
@@ -580,5 +582,6 @@ void extract(bool const with_platforms,
 
   lookup{w, out, cista::mmap::protection::WRITE}.build_rtree();
 }
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -230,7 +230,8 @@ struct way_handler : public osm::handler::Handler {
       platforms_->way(way_idx, w);
     }
 
-    if (it != end(rel_ways_) && it->second.pl_ != platform_idx_t::invalid()) {
+    if (platforms_ != nullptr && it != end(rel_ways_) &&
+        it->second.pl_ != platform_idx_t::invalid()) {
       platforms_->platform_ref_[it->second.pl_].push_back(to_value(way_idx));
     }
 
@@ -560,7 +561,7 @@ void extract(bool const with_platforms,
             }) &
             oneapi::tbb::make_filter<osm_mem::Buffer, void>(
                 oneapi::tbb::filter_mode::parallel,
-                [&](osm_mem::Buffer&& buf) { osm::apply(buf, h); }));
+                [&](osm_mem::Buffer const& buf) { osm::apply(buf, h); }));
 
     reader.close();
     pt->update(pt->in_high_);

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -42,7 +42,6 @@ using namespace std::string_view_literals;
 
 namespace osr {
 
-// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 struct osm_restriction {
   bool valid() const {
     return from_ != osm_way_idx_t::invalid() &&
@@ -582,6 +581,5 @@ void extract(bool const with_platforms,
 
   lookup{w, out, cista::mmap::protection::WRITE}.build_rtree();
 }
-// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/lookup.cc
+++ b/src/lookup.cc
@@ -8,7 +8,6 @@
 
 namespace osr {
 
-// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 lookup::lookup(ways const& ways,
                std::filesystem::path p,
                cista::mmap::protection mode)
@@ -75,6 +74,5 @@ hash_set<node_idx_t> lookup::find_elevators(geo::box const& b) const {
   });
   return elevators;
 }
-// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/lookup.cc
+++ b/src/lookup.cc
@@ -8,6 +8,7 @@
 
 namespace osr {
 
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 lookup::lookup(ways const& ways,
                std::filesystem::path p,
                cista::mmap::protection mode)
@@ -74,5 +75,6 @@ hash_set<node_idx_t> lookup::find_elevators(geo::box const& b) const {
   });
   return elevators;
 }
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/route.cc
+++ b/src/route.cc
@@ -292,7 +292,7 @@ std::optional<path> route(ways const& w,
                           bitvec<node_idx_t> const* blocked,
                           sharing_data const* sharing) {
   if (auto const direct = try_direct(from, to); direct.has_value()) {
-    return *direct;
+    return direct;
   }
 
   d.reset(max);

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -4,6 +4,7 @@
 
 namespace osr {
 
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 ways::ways(std::filesystem::path p, cista::mmap::protection const mode)
     : p_{std::move(p)},
       mode_{mode},
@@ -161,5 +162,6 @@ cista::wrapped<ways::routing> ways::routing::read(
 void ways::routing::write(std::filesystem::path const& p) const {
   cista::write(p / "routing.bin", *this);
 }
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -4,7 +4,6 @@
 
 namespace osr {
 
-// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 ways::ways(std::filesystem::path p, cista::mmap::protection const mode)
     : p_{std::move(p)},
       mode_{mode},
@@ -162,6 +161,5 @@ cista::wrapped<ways::routing> ways::routing::read(
 void ways::routing::write(std::filesystem::path const& p) const {
   cista::write(p / "routing.bin", *this);
 }
-// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 }  // namespace osr

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -159,7 +159,7 @@ cista::wrapped<ways::routing> ways::routing::read(
 }
 
 void ways::routing::write(std::filesystem::path const& p) const {
-  return cista::write(p / "routing.bin", *this);
+  cista::write(p / "routing.bin", *this);
 }
 
 }  // namespace osr


### PR DESCRIPTION
This will remove `AnalyzeTemporaryDtors`, which was removed with clang-tidy 18: https://github.com/llvm/llvm-project/issues/62020
Additionally some errors will be fixed, reported by `clang-tidy`. More complex to fix errors will be ignored for now.