### PR TITLE
Benchmark improvement

### DIFF
--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -74,8 +74,7 @@ void print_result(std::vector<benchmark_result> const& var,
                         return std::move(sum) + res.duration_;
                       }) /
       var.size()};
-  std::cout << "\n--- duration (" << profile << ") --- (n = " << var.size()
-            << ")"
+  std::cout << "\n--- profile: " << profile << " --- (n = " << var.size() << ")"
             << "\n  max: " << var.back() << "\n  avg: " << avg << "\n----------"
             << "\n  10%: " << quantile(var, 0.1)
             << "\n  20%: " << quantile(var, 0.2)

--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -1,4 +1,6 @@
+#include <chrono>
 #include <filesystem>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -26,8 +28,8 @@ public:
   explicit settings() : configuration("Options") {
     param(data_dir_, "data,d", "Data directory");
     param(threads_, "threads,t", "Number of routing threads");
-    param(n_queries_, "n", "Number of queries");
-    param(max_dist_, "r", "Radius");
+    param(n_queries_, ",n", "Number of queries");
+    param(max_dist_, "radius,r", "Radius");
   }
 
   fs::path data_dir_{"osr"};
@@ -35,6 +37,46 @@ public:
   unsigned max_dist_{1200};
   unsigned threads_{std::thread::hardware_concurrency()};
 };
+
+struct benchmark_result {
+  friend std::ostream& operator<<(std::ostream& out,
+                                  benchmark_result const& br) {
+    using double_milliseconds_t =
+        std::chrono::duration<double, std::ratio<1, 1000>>;
+    out << "(duration: " << std::fixed << std::setprecision(3) << std::setw(10)
+        << std::chrono::duration_cast<double_milliseconds_t>(br.duration_)
+        << ")";
+    return out;
+  }
+
+  std::chrono::microseconds duration_;
+};
+
+// needs sorted vector
+benchmark_result quantile(std::vector<benchmark_result> const& v, double q) {
+  q = std::clamp(q, 0.0, 1.0);
+  if (q == 1.0) {
+    return v.back();
+  }
+  return v[static_cast<std::size_t>(v.size() * q)];
+}
+
+void print_result(std::vector<benchmark_result> const& var,
+                  std::string const& var_name) {
+  std::cout << "\n--- " << var_name << " --- (n = " << var.size() << ")"
+            << "\n  10%: " << quantile(var, 0.1)
+            << "\n  20%: " << quantile(var, 0.2)
+            << "\n  30%: " << quantile(var, 0.3)
+            << "\n  40%: " << quantile(var, 0.4)
+            << "\n  50%: " << quantile(var, 0.5)
+            << "\n  60%: " << quantile(var, 0.6)
+            << "\n  70%: " << quantile(var, 0.7)
+            << "\n  80%: " << quantile(var, 0.8)
+            << "\n  90%: " << quantile(var, 0.9)
+            << "\n  99%: " << quantile(var, 0.99)
+            << "\n99.9%: " << quantile(var, 0.999) << "\n  max: " << var.back()
+            << "\n-----------------------------\n";
+}
 
 int main(int argc, char const* argv[]) {
   auto opt = settings{};
@@ -59,15 +101,18 @@ int main(int argc, char const* argv[]) {
 
   auto const w = ways{opt.data_dir_, cista::mmap::protection::READ};
 
-  auto timer = utl::scoped_timer{"timer"};
   auto threads = std::vector<std::thread>(std::max(1U, opt.threads_));
+  auto results = std::vector<benchmark_result>{};
+  results.reserve(opt.n_queries_);
   auto i = std::atomic_size_t{0U};
+  auto m = std::mutex{};
   for (auto& t : threads) {
     t = std::thread([&]() {
       auto d = dijkstra<car>{};
       auto h = cista::BASE_HASH;
       auto n = 0U;
       while (i.fetch_add(1U) < opt.n_queries_) {
+        auto const start_time = std::chrono::steady_clock::now();
         auto const start =
             node_idx_t{cista::hash_combine(h, ++n, i.load()) % w.n_nodes()};
         d.reset(opt.max_dist_);
@@ -77,6 +122,13 @@ int main(int argc, char const* argv[]) {
                     car::label{car::node{start, 0, direction::kBackward}, 0U});
         d.run<direction::kForward, false>(w, *w.r_, opt.max_dist_, nullptr,
                                           nullptr);
+        auto const end_time = std::chrono::steady_clock::now();
+        {
+          auto const guard = std::lock_guard{m};
+          results.emplace_back(
+              std::chrono::duration_cast<decltype(benchmark_result::duration_)>(
+                  end_time - start_time));
+        }
       }
     });
   }
@@ -84,4 +136,9 @@ int main(int argc, char const* argv[]) {
   for (auto& t : threads) {
     t.join();
   }
+
+  std::ranges::sort(results, std::less<>{},
+                    [](benchmark_result const& res) { return res.duration_; });
+
+  print_result(results, "duration");
 }

--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <filesystem>
 #include <mutex>
+#include <numeric>
 #include <thread>
 #include <vector>
 
@@ -63,7 +64,14 @@ benchmark_result quantile(std::vector<benchmark_result> const& v, double q) {
 
 void print_result(std::vector<benchmark_result> const& var,
                   std::string const& var_name) {
+  auto const avg = benchmark_result{
+      std::accumulate(var.begin(), var.end(), std::chrono::microseconds{0U},
+                      [](auto&& sum, auto const& res) {
+                        return std::move(sum) + res.duration_;
+                      }) /
+      var.size()};
   std::cout << "\n--- " << var_name << " --- (n = " << var.size() << ")"
+            << "\n  max: " << var.back() << "\n  avg: " << avg << "\n----------"
             << "\n  10%: " << quantile(var, 0.1)
             << "\n  20%: " << quantile(var, 0.2)
             << "\n  30%: " << quantile(var, 0.3)
@@ -74,7 +82,7 @@ void print_result(std::vector<benchmark_result> const& var,
             << "\n  80%: " << quantile(var, 0.8)
             << "\n  90%: " << quantile(var, 0.9)
             << "\n  99%: " << quantile(var, 0.99)
-            << "\n99.9%: " << quantile(var, 0.999) << "\n  max: " << var.back()
+            << "\n99.9%: " << quantile(var, 0.999)
             << "\n-----------------------------\n";
 }
 

--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -149,9 +149,8 @@ int main(int argc, char const* argv[]) {
           auto const end_time = std::chrono::steady_clock::now();
           {
             auto const guard = std::lock_guard{m};
-            results.emplace_back(std::chrono::duration_cast<
-                                 decltype(benchmark_result::duration_)>(
-                end_time - start_time));
+            results.emplace_back(benchmark_result{std::chrono::duration_cast<
+                decltype(benchmark_result::duration_)>(end_time - start_time)});
           }
         }
       });

--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -14,15 +14,15 @@
 
 #include "conf/options_parser.h"
 
-#include "osr/routing/profile.h"
-#include "osr/types.h"
 #include "utl/timer.h"
 
 #include "osr/lookup.h"
 #include "osr/routing/dijkstra.h"
+#include "osr/routing/profile.h"
 #include "osr/routing/profiles/bike.h"
 #include "osr/routing/profiles/car.h"
 #include "osr/routing/route.h"
+#include "osr/types.h"
 #include "osr/ways.h"
 
 namespace fs = std::filesystem;

--- a/exe/benchmark.cc
+++ b/exe/benchmark.cc
@@ -50,7 +50,8 @@ struct benchmark_result {
         std::chrono::duration<double, std::ratio<1, 1000>>;
     out << "(duration: " << std::fixed << std::setprecision(3) << std::setw(10)
         << std::chrono::duration_cast<double_milliseconds_t>(br.duration_)
-        << ")";
+               .count()
+        << "ms)";
     return out;
   }
 


### PR DESCRIPTION
Adds a more detailed output for benchmark timings.

Example output:

```
--- profile: car --- (n = 2000)
  max: (duration:    866.585ms)
  avg: (duration:    116.642ms)
----------
  10%: (duration:      0.214ms)
  20%: (duration:      0.260ms)
  30%: (duration:      0.376ms)
  40%: (duration:      0.545ms)
  50%: (duration:     43.448ms)
  60%: (duration:     91.361ms)
  70%: (duration:    151.477ms)
  80%: (duration:    238.431ms)
  90%: (duration:    352.169ms)
  99%: (duration:    640.477ms)
99.9%: (duration:    791.465ms)
-----------------------------

--- profile: bike --- (n = 2000)
  max: (duration:     54.563ms)
  avg: (duration:      1.794ms)
----------
  10%: (duration:      0.015ms)
  20%: (duration:      0.037ms)
  30%: (duration:      0.348ms)
  40%: (duration:      0.594ms)
  50%: (duration:      0.895ms)
  60%: (duration:      1.362ms)
  70%: (duration:      1.914ms)
  80%: (duration:      2.753ms)
  90%: (duration:      4.588ms)
  99%: (duration:     11.674ms)
99.9%: (duration:     33.224ms)
-----------------------------
```