### PR TITLE
Fix build failure on gcc 15.0.1

### DIFF
--- a/src/route.cc
+++ b/src/route.cc
@@ -279,20 +279,22 @@ best_candidate(ways const& w,
 std::optional<path> try_direct(osr::location const& from,
                                osr::location const& to) {
   auto const dist = geo::distance(from.pos_, to.pos_);
-  return dist < 8.0
-             ? std::optional{path{.cost_ = 60U,
-                                  .dist_ = dist,
-                                  .segments_ = {path::segment{
-                                      .polyline_ = {from.pos_, to.pos_},
-                                      .from_level_ = from.lvl_,
-                                      .to_level_ = to.lvl_,
-                                      .from_ = node_idx_t::invalid(),
-                                      .to_ = node_idx_t::invalid(),
-                                      .way_ = way_idx_t::invalid(),
-                                      .cost_ = 60U,
-                                      .dist_ = static_cast<distance_t>(dist)}},
-                                  .uses_elevator_ = false}}
-             : std::nullopt;
+  if (dist < 8.0) {
+    return std::optional{path{
+        .cost_ = 60U,
+        .dist_ = dist,
+        .segments_ = {path::segment{.polyline_ = {from.pos_, to.pos_},
+                                    .from_level_ = from.lvl_,
+                                    .to_level_ = to.lvl_,
+                                    .from_ = node_idx_t::invalid(),
+                                    .to_ = node_idx_t::invalid(),
+                                    .way_ = way_idx_t::invalid(),
+                                    .cost_ = 60U,
+                                    .dist_ = static_cast<distance_t>(dist)}},
+        .uses_elevator_ = false}};
+  } else {
+    return std::nullopt;
+  }
 }
 
 template <typename Profile>


### PR DESCRIPTION
g++ fails with
```
route.cc:296:1: error: dangling pointer to an unnamed temporary may be used [-Werror=dangling-pointer=]
```

I'm not entirely convinced that the diagnostic actually makes sense, but
this at least allows building again.
