### PR TITLE
speedup + progressbar for build components

### DIFF
--- a/src/extract.cc
+++ b/src/extract.cc
@@ -618,12 +618,11 @@ void extract(bool const with_platforms,
     }
   }
 
-  pt->status("Load OSM / Big Street Neighbors")
-      .in_high(w.n_ways())
-      .out_bounds(95, 100);
+  pt->status("Big Street Neighbors").in_high(w.n_ways()).out_bounds(95, 99);
   w.compute_big_street_neighbors();
   w.r_->write(out);
 
+  pt->status("Build R-Tree").in_high(1).out_bounds(99, 100);
   lookup{w, out, cista::mmap::protection::WRITE}.build_rtree();
 }
 

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -46,7 +46,6 @@ void ways::build_components() {
   };
 
   auto pt = utl::get_active_progress_tracker_or_activate("osr");
-
   pt->status("Build components").in_high(n_ways()).out_bounds(75, 90);
 
   auto next_component_idx = component_idx_t{0U};

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -28,7 +28,7 @@ ways::ways(std::filesystem::path p, cista::mmap::protection const mode)
 void ways::build_components() {
   auto q = hash_set<way_idx_t>{};
   auto flood_fill = [&](way_idx_t const way_idx, component_idx_t const c) {
-    q.clear();
+    assert(q.empty());
     q.insert(way_idx);
     while (!q.empty()) {
       auto const next = *q.begin();
@@ -45,6 +45,10 @@ void ways::build_components() {
     }
   };
 
+  auto pt = utl::get_active_progress_tracker_or_activate("osr");
+
+  pt->status("Build components").in_high(n_ways()).out_bounds(75, 90);
+
   auto next_component_idx = component_idx_t{0U};
   r_->way_component_.resize(n_ways(), component_idx_t::invalid());
   for (auto i = 0U; i != n_ways(); ++i) {
@@ -55,6 +59,7 @@ void ways::build_components() {
     }
     c = next_component_idx++;
     flood_fill(way_idx, c);
+    pt->increment();
   }
 }
 


### PR DESCRIPTION
q.clear() was >90% of CPU time
but q.empty() is also invariant