### PR TITLE
Add function to check for defined level

### DIFF
--- a/include/osr/types.h
+++ b/include/osr/types.h
@@ -168,6 +168,8 @@ struct level_t {
     return (v_ == kNoLevel) ? 0.0F : (kMinLevel + ((v_ - 1U) / 4.0F));
   }
 
+  constexpr bool has_level() const { return v_ != kNoLevel; }
+
   constexpr level_t() = default;
 
   auto operator<=>(level_t const&) const = default;

--- a/test/level_test.cc
+++ b/test/level_test.cc
@@ -20,4 +20,11 @@ TEST(osr, level) {
 
   auto const lvl_minus_3 = level_t{-3.0F}.to_float();
   EXPECT_EQ(-3.0F, lvl_minus_3);
+
+  // Test if level has actual level
+  EXPECT_TRUE(level_t{0.0F}.has_level());
+
+  auto const lvl_no_level = level_t{kNoLevel};
+  EXPECT_FALSE(lvl_no_level.has_level());
+  EXPECT_EQ(0.0F, lvl_no_level.to_float());  // Special case
 }


### PR DESCRIPTION
This function is intended to check, if `level_t` contains an actual level. Or if no level is set.
Will be used to fix wildcard matching for the `/plan` endpoint.