### PR TITLE
z curve ordered insertion speeds up rtree by about one order of magnitude

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -13,7 +13,7 @@
 [geo]
   url=git@github.com:motis-project/geo.git
   branch=master
-  commit=d862550fd867cd5435225b5f0998981ec4fc2ae3
+  commit=31b1ac29d386d7b53d0112dccaad37e84b8ae567
 [cista]
   url=git@github.com:felixguendling/cista.git
   branch=master

--- a/src/lookup.cc
+++ b/src/lookup.cc
@@ -24,7 +24,21 @@ lookup::lookup(ways const& ways,
       ways_{ways} {}
 
 void lookup::build_rtree() {
-  for (auto way = way_idx_t{0U}; way != ways_.n_ways(); ++way) {
+  auto sorted_ways = std::vector<way_idx_t>();
+  sorted_ways.resize(ways_.n_ways());
+  std::iota(sorted_ways.begin(), sorted_ways.end(), way_idx_t{0});
+
+  std::stable_sort(
+      sorted_ways.begin(), sorted_ways.end(),
+      [&](way_idx_t const a, way_idx_t const b) {
+        return geo::morton_encode(
+                   ways_
+                       .way_polylines_[a][ways_.way_polylines_[a].size() / 2]) <
+               geo::morton_encode(
+                   ways_.way_polylines_[b][ways_.way_polylines_[b].size() / 2]);
+      });
+
+  for (auto way : sorted_ways) {
     auto b = geo::box{};
     for (auto const& c : ways_.way_polylines_[way]) {
       b.extend(c);


### PR DESCRIPTION
rtree in memory doesn't help at all

but insertion order into the tree appears to matter (cf. https://github.com/tidwall/rtree.c#testing-and-benchmarks), maybe a Hilbert curve would be even better

speeds up `compute_provider_routing_data` by about 70% in preliminary tests (mm rtree import currently running)

needs https://github.com/mority/geo/tree/morton