### PR TITLE
Small size optimization for way-aware routing profiles

### DIFF
--- a/include/osr/routing/astar.h
+++ b/include/osr/routing/astar.h
@@ -13,6 +13,7 @@
 #include "osr/elevation_storage.h"
 #include "osr/routing/additional_edge.h"
 #include "osr/routing/dial.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/profile.h"
 #include "osr/types.h"
 #include "osr/ways.h"
@@ -45,6 +46,7 @@ struct astar {
     pq_.clear();
     pq_.n_buckets(max + 1U);
     cost_.clear();
+    arena_.reset();
     max_reached_ = false;
     destinations_.clear();
     remaining_destinations_ = 0U;
@@ -75,7 +77,8 @@ struct astar {
                 "astar: add_destination must be called before add_start");
     auto const heur = heuristic(params, w, sharing, l.get_node().get_node());
     if (cost_[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                             node::invalid(), duration)) {
+                                             node::invalid(), duration, *w.r_,
+                                             arena_)) {
       auto const cost_with_heur = l.cost() + heur;
       if constexpr (kDebug) {
         std::cout << "START ";
@@ -209,7 +212,7 @@ struct astar {
               next.track(l, r, way, neighbor.get_node(), track);
               if (!cost_[neighbor.get_key()].update(
                       next, neighbor, static_cast<cost_t>(total), curr_node,
-                      total_duration)) {
+                      total_duration, r, arena_)) {
                 return false;
               }
               pq_.push(std::move(next));
@@ -301,6 +304,7 @@ struct astar {
 
   dial<label, get_bucket> pq_{get_bucket{}};
   ankerl::unordered_dense::map<key, entry, hash> cost_;
+  entry_storage_arena arena_;
   bool max_reached_{};
 
   std::vector<node> destinations_;

--- a/include/osr/routing/bidirectional.h
+++ b/include/osr/routing/bidirectional.h
@@ -11,6 +11,7 @@
 #include "osr/location.h"
 #include "osr/routing/additional_edge.h"
 #include "osr/routing/dial.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/profile.h"
 #include "osr/routing/sharing_data.h"
 #include "osr/types.h"
@@ -55,6 +56,7 @@ struct bidirectional {
     pq2_.n_buckets(max + 1U);
     cost1_.clear();
     cost2_.clear();
+    arena_.reset();
     clear_mp();
     start_loc_ = start_loc;
     end_loc_ = end_loc;
@@ -86,7 +88,8 @@ struct bidirectional {
     auto const heur = heuristic(params, w, l.n_, dir, sharing);
     if (l.cost() + heur < d.n_buckets() - 1U &&
         cost_map[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                                node::invalid(), duration)) {
+                                                node::invalid(), duration,
+                                                *w.r_, arena_)) {
       auto const total = static_cast<cost_t>(l.cost() + heur);
       d.push(label{l.get_node(), total});
     }
@@ -244,9 +247,9 @@ struct bidirectional {
             }
             auto next = label{neighbor, static_cast<cost_t>(heur)};
             next.track(l, r, way, neighbor.get_node(), track);
-            if (!costs[neighbor.get_key()].update(next, neighbor,
-                                                  static_cast<cost_t>(total),
-                                                  curr, total_duration)) {
+            if (!costs[neighbor.get_key()].update(
+                    next, neighbor, static_cast<cost_t>(total), curr,
+                    total_duration, r, arena_)) {
               return false;
             }
             pq.push(std::move(next));
@@ -431,6 +434,7 @@ struct bidirectional {
   cost_t best_cost_;
   ankerl::unordered_dense::map<key, entry, hash> cost1_;
   ankerl::unordered_dense::map<key, entry, hash> cost2_;
+  entry_storage_arena arena_;
   cost_t radius_;
   double distance_lon_degrees_;
   bool search_bounds_valid_{};

--- a/include/osr/routing/dijkstra.h
+++ b/include/osr/routing/dijkstra.h
@@ -10,6 +10,7 @@
 #include "osr/elevation_storage.h"
 #include "osr/routing/additional_edge.h"
 #include "osr/routing/dial.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/profile.h"
 #include "osr/types.h"
 #include "osr/ways.h"
@@ -37,6 +38,7 @@ struct dijkstra {
     pq_.clear();
     pq_.n_buckets(max + 1U);
     cost_.clear();
+    arena_.reset();
     max_reached_ = false;
     if constexpr (EarlyTermination) {
       destinations_.clear();
@@ -52,7 +54,8 @@ struct dijkstra {
 
   void add_start(ways const& w, label const l, duration_t const duration) {
     if (cost_[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                             node::invalid(), duration)) {
+                                             node::invalid(), duration, *w.r_,
+                                             arena_)) {
       if constexpr (kDebug) {
         std::cout << "START ";
         l.get_node().print(std::cout, w);
@@ -149,9 +152,9 @@ struct dijkstra {
                 clamp_add_duration(curr_duration, duration);
             auto next = label{neighbor, static_cast<cost_t>(total)};
             next.track(l, r, way, neighbor.get_node(), track);
-            if (cost_[neighbor.get_key()].update(next, neighbor,
-                                                 static_cast<cost_t>(total),
-                                                 curr, total_duration)) {
+            if (cost_[neighbor.get_key()].update(
+                    next, neighbor, static_cast<cost_t>(total), curr,
+                    total_duration, r, arena_)) {
               pq_.push(std::move(next));
 
               if constexpr (kDebug) {
@@ -196,6 +199,7 @@ struct dijkstra {
 
   dial<label, get_bucket> pq_{get_bucket{}};
   ankerl::unordered_dense::map<key, entry, hash> cost_;
+  entry_storage_arena arena_;
   bool max_reached_{};
 
   // for early termination

--- a/include/osr/routing/entry_storage.h
+++ b/include/osr/routing/entry_storage.h
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
+#include <type_traits>
 
 #include "osr/routing/entry_storage_arena.h"
 #include "osr/types.h"
@@ -34,6 +36,24 @@ struct entry_storage {
 
   static_assert(kInlineWays <= kMaxWays);
 
+  struct inline_storage {
+    bool is_overflow_{false};
+    std::array<Slot, kInlineN> slots_{};
+  };
+
+  struct overflow_storage {
+    bool is_overflow_{true};
+    Slot* slots_{nullptr};
+  };
+
+  union storage {
+    inline_storage inline_{};
+    overflow_storage overflow_;
+  };
+
+  static_assert(std::is_standard_layout_v<storage>);
+  static_assert(std::is_trivially_copyable_v<storage>);
+
   static constexpr std::size_t index(std::size_t const way,
                                      direction const dir) noexcept {
     return kExtra + 2U * way + (dir == direction::kForward ? 0U : 1U);
@@ -50,35 +70,38 @@ struct entry_storage {
   }
 
   Slot operator[](std::size_t const i) const noexcept {
-    if (overflow_ != nullptr) [[unlikely]] {
-      return overflow_[i];
+    if (is_overflow()) [[unlikely]] {
+      return storage_.overflow_.slots_[i];
     }
-    return i < kInlineN ? inline_[i] : Slot{};
+    return i < kInlineN ? storage_.inline_.slots_[i] : Slot{};
   }
 
   Slot& slot(std::size_t const i,
              ways::routing const& w,
              node_idx_t const n,
              entry_storage_arena& a) {
-    if (overflow_ == nullptr) [[likely]] {
+    if (!is_overflow()) [[likely]] {
       if (i < kInlineN) [[likely]] {
-        return inline_[i];
+        return storage_.inline_.slots_[i];
       }
       promote(slot_count(w, n), a);
       assert(i < slot_count(w, n));
     }
-    return overflow_[i];
+    return storage_.overflow_.slots_[i];
   }
+
+  bool is_overflow() const noexcept { return storage_.inline_.is_overflow_; }
 
   void promote(std::size_t const n_slots, entry_storage_arena& a) {
+    assert(!is_overflow());
     assert(n_slots >= kInlineN && n_slots <= kN);
     auto* const o = a.template create_array<Slot>(n_slots);
-    std::copy(begin(inline_), end(inline_), o);
-    overflow_ = o;
+    std::copy(begin(storage_.inline_.slots_), end(storage_.inline_.slots_), o);
+    std::destroy_at(&storage_.inline_);
+    std::construct_at(&storage_.overflow_, overflow_storage{true, o});
   }
 
-  std::array<Slot, kInlineN> inline_{};
-  Slot* overflow_{nullptr};
+  storage storage_;
 };
 
 }  // namespace osr

--- a/include/osr/routing/entry_storage.h
+++ b/include/osr/routing/entry_storage.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+
+#include <algorithm>
+#include <array>
+
+#include "osr/routing/entry_storage_arena.h"
+#include "osr/types.h"
+#include "osr/ways.h"
+
+namespace osr {
+
+// Inline storage for the per node entries during routing for way aware
+// profiles, where entries provide a slot per (way, direction) pair of the node.
+//
+// Since most nodes have very few ways, the first kInlineWaysPerNode ways per
+// entry are stored inline. If a slot outside that range is written, the entry
+// is promoted to an overflow block allocated from the arena, which then stores
+// all slots for that entry (= inline ignored).
+//
+// Extra is the number of profile specific slots that precede the way slots
+// (e.g. walking state for car_sharing).
+template <typename Slot, std::size_t Extra>
+struct entry_storage {
+  using slot_t = Slot;
+
+  static constexpr auto const kExtra = Extra;
+  static constexpr auto const kMaxWays = std::size_t{kMaxWaysPerNode};
+  static constexpr auto const kInlineWays = std::size_t{kInlineWaysPerNode};
+  static constexpr auto const kN = kExtra + 2U * kMaxWays;
+  static constexpr auto const kInlineN = kExtra + 2U * kInlineWays;
+
+  static_assert(kInlineWays <= kMaxWays);
+
+  static constexpr std::size_t index(std::size_t const way,
+                                     direction const dir) noexcept {
+    return kExtra + 2U * way + (dir == direction::kForward ? 0U : 1U);
+  }
+
+  static constexpr std::size_t slot_count(std::size_t const n_ways) noexcept {
+    return kExtra + 2U * n_ways;
+  }
+
+  static std::size_t slot_count(ways::routing const& w,
+                                node_idx_t const n) noexcept {
+    return to_idx(n) < w.node_ways_.size() ? slot_count(w.node_ways_[n].size())
+                                           : kN /* (additional nodes) */;
+  }
+
+  Slot operator[](std::size_t const i) const noexcept {
+    if (overflow_ != nullptr) [[unlikely]] {
+      return overflow_[i];
+    }
+    return i < kInlineN ? inline_[i] : Slot{};
+  }
+
+  Slot& slot(std::size_t const i,
+             ways::routing const& w,
+             node_idx_t const n,
+             entry_storage_arena& a) {
+    if (overflow_ == nullptr) [[likely]] {
+      if (i < kInlineN) [[likely]] {
+        return inline_[i];
+      }
+      promote(slot_count(w, n), a);
+      assert(i < slot_count(w, n));
+    }
+    return overflow_[i];
+  }
+
+  void promote(std::size_t const n_slots, entry_storage_arena& a) {
+    assert(n_slots >= kInlineN && n_slots <= kN);
+    auto* const o = a.template create_array<Slot>(n_slots);
+    std::copy(begin(inline_), end(inline_), o);
+    overflow_ = o;
+  }
+
+  std::array<Slot, kInlineN> inline_{};
+  Slot* overflow_{nullptr};
+};
+
+}  // namespace osr

--- a/include/osr/routing/entry_storage_arena.h
+++ b/include/osr/routing/entry_storage_arena.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace osr {
+
+// Bump allocator for the overflow blocks of routing entries
+struct entry_storage_arena {
+  static constexpr auto const kChunkSize = std::size_t{64U * 1024U};
+
+  template <typename T>
+  T* create_array(std::size_t const n) {
+    static_assert(std::is_trivially_destructible_v<T>,
+                  "arena blocks are never destructed");
+    static_assert(alignof(T) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+    assert(n * sizeof(T) <= kChunkSize);
+    auto* const p = static_cast<T*>(allocate(n * sizeof(T), alignof(T)));
+    std::uninitialized_value_construct_n(p, n);
+    return p;
+  }
+
+  void* allocate(std::size_t const size, std::size_t const align) {
+    // Round the current offset up to the alignment boundary
+    auto const offset = (offset_ + align - 1U) & ~(align - 1U);
+    if (chunk_ < chunks_.size() && offset + size <= kChunkSize) [[likely]] {
+      offset_ = offset + size;
+      return chunks_[chunk_].get() + offset;
+    }
+    return allocate_chunk(size);
+  }
+
+  void reset() noexcept {
+    chunk_ = 0U;
+    offset_ = 0U;
+  }
+
+  void* allocate_chunk(std::size_t const size) {
+    if (chunk_ < chunks_.size()) {
+      ++chunk_;
+    }
+    if (chunk_ == chunks_.size()) {
+      chunks_.emplace_back(
+          std::make_unique_for_overwrite<std::byte[]>(kChunkSize));
+    }
+    offset_ = size;
+    return chunks_[chunk_].get();
+  }
+
+  std::vector<std::unique_ptr<std::byte[]>> chunks_;
+  std::size_t chunk_{0U};
+  std::size_t offset_{0U};
+};
+
+}  // namespace osr

--- a/include/osr/routing/profile.h
+++ b/include/osr/routing/profile.h
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/sharing_data.h"
@@ -67,8 +68,12 @@ concept IsEntry =
                   Label const& label,
                   cost_t const cost,
                   duration_t const duration,
+                  ways::routing const& w,
+                  entry_storage_arena& arena,
                   path& p) {
-      { entry.update(label, node, cost, node, duration) } -> std::same_as<bool>;
+      {
+        entry.update(label, node, cost, node, duration, w, arena)
+      } -> std::same_as<bool>;
     };
 
 template <typename Hash, typename NodeKey>

--- a/include/osr/routing/profiles/bike.h
+++ b/include/osr/routing/profiles/bike.h
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/types.h"
@@ -119,7 +120,9 @@ struct bike {
                           node const n,
                           cost_t const c,
                           node const pred,
-                          duration_t const) noexcept {
+                          duration_t const,
+                          ways::routing const&,
+                          entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
       if (c < cost_[idx]) {
         cost_[idx] = c;

--- a/include/osr/routing/profiles/bike_sharing.h
+++ b/include/osr/routing/profiles/bike_sharing.h
@@ -12,6 +12,7 @@
 
 #include "osr/elevation_storage.h"
 #include "osr/routing/additional_edge.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/bike.h"
@@ -232,7 +233,9 @@ struct bike_sharing {
                           node const n,
                           cost_t const c,
                           node const pred,
-                          duration_t const) noexcept {
+                          duration_t const,
+                          ways::routing const&,
+                          entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
       if (c < cost_[idx]) {
         cost_[idx] = c;

--- a/include/osr/routing/profiles/car.h
+++ b/include/osr/routing/profiles/car.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <bitset>
 #include <optional>
 #include <tuple>
 
 #include "boost/json/object.hpp"
 
-#include "utl/helpers/algorithm.h"
-
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/common.h"
@@ -18,6 +16,13 @@
 namespace osr {
 
 struct sharing_data;
+
+struct car_slot {
+  node_idx_t pred_{node_idx_t::invalid()};
+  cost_t cost_{kInfeasible};
+  way_pos_t pred_way_{0U};
+  bool pred_dir_{false};
+};
 
 template <bool IsBus>
 struct generic_car {
@@ -105,57 +110,53 @@ struct generic_car {
   };
 
   struct entry {
-    static constexpr auto const kMaxWays = way_pos_t{16U};
-    static constexpr auto const kN = kMaxWays * 2U /* FWD+BWD */;
+    using slot_t = car_slot;
 
-    entry() {
-      utl::fill(cost_, kInfeasible);
-      utl::fill(pred_, node_idx_t::invalid());
-      utl::fill(pred_way_, way_pos_t{0});
-    }
+    using storage_t = entry_storage<slot_t, 0U>;
+    static constexpr auto const kN = storage_t::kN /* FWD+BWD */;
 
-    constexpr std::optional<node> pred(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return pred_[idx] == node_idx_t::invalid()
+    std::optional<node> pred(node const n) const noexcept {
+      auto const s = s_[get_index(n)];
+      return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{pred_[idx], pred_way_[idx],
-                                      to_dir(pred_dir_[idx])}};
+                 : std::optional{
+                       node{s.pred_, s.pred_way_, to_dir(s.pred_dir_)}};
     }
 
-    constexpr cost_t cost(node const n) const noexcept {
-      return cost_[get_index(n)];
-    }
+    cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
     constexpr duration_t duration(node const n) const noexcept {
       return duration_from_cost(cost(n));
     }
 
-    constexpr bool update(label const&,
-                          node const n,
-                          cost_t const c,
-                          node const pred,
-                          duration_t const) noexcept {
-      auto const idx = get_index(n);
-      if (c < cost_[idx]) {
-        cost_[idx] = c;
-        pred_[idx] = pred.n_;
-        pred_way_[idx] = pred.way_;
-        pred_dir_[idx] = to_bool(pred.dir_);
-        return true;
+    bool update(label const&,
+                node const n,
+                cost_t const c,
+                node const pred,
+                duration_t const,
+                ways::routing const& w,
+                entry_storage_arena& a) {
+      auto& s = s_.slot(get_index(n), w, n.n_, a);
+      if (c >= s.cost_) {
+        return false;
       }
-      return false;
+      s.cost_ = c;
+      s.pred_ = pred.n_;
+      s.pred_way_ = pred.way_;
+      s.pred_dir_ = to_bool(pred.dir_);
+      return true;
     }
 
     void write(node, path&) const {}
 
     static constexpr node get_node(node_idx_t const n,
                                    std::size_t const index) {
-      return node{n, static_cast<way_pos_t>(index % kMaxWays),
-                  to_dir((index / kMaxWays) != 0U)};
+      return node{n, static_cast<way_pos_t>(index / 2U),
+                  to_dir((index % 2U) != 0U)};
     }
 
     static constexpr std::size_t get_index(node const n) {
-      return (n.dir_ == direction::kForward ? 0U : 1U) * kMaxWays + n.way_;
+      return storage_t::index(n.way_, n.dir_);
     }
 
     static constexpr direction to_dir(bool const b) {
@@ -166,10 +167,7 @@ struct generic_car {
       return d == direction::kForward ? false : true;
     }
 
-    std::array<node_idx_t, kN> pred_;
-    std::array<way_pos_t, kN> pred_way_;
-    std::bitset<kN> pred_dir_;
-    std::array<cost_t, kN> cost_;
+    storage_t s_;
   };
 
   struct hash {

--- a/include/osr/routing/profiles/car_parking.h
+++ b/include/osr/routing/profiles/car_parking.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <bitset>
 #include <optional>
 
 #include "boost/json.hpp"
 
-#include "utl/helpers/algorithm.h"
-
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/car.h"
@@ -15,6 +13,15 @@
 #include "osr/ways.h"
 
 namespace osr {
+
+struct car_parking_slot {
+  node_idx_t pred_{node_idx_t::invalid()};
+  cost_t cost_{kInfeasible};
+  level_t pred_lvl_{kNoLevel};
+  way_pos_t pred_way_{0U};
+  bool pred_dir_{false};
+  bool pred_type_{false};
+};
 
 struct sharing_data;
 
@@ -136,58 +143,50 @@ struct car_parking {
   };
 
   struct entry {
-    static constexpr auto const kMaxWays = way_pos_t{16U};
-    static constexpr auto const kN = kMaxWays * 2U + 1 /* FWD+BWD + foot */;
+    using slot_t = car_parking_slot;
 
-    entry() {
-      utl::fill(cost_, kInfeasible);
-      utl::fill(pred_, node_idx_t::invalid());
-      utl::fill(pred_way_, way_pos_t{0});
-      utl::fill(pred_lvl_, kNoLevel);
-    }
+    using storage_t = entry_storage<slot_t, 1U>;  // 1 extra for foot
+    static constexpr auto const kN = storage_t::kN;
 
-    constexpr std::optional<node> pred(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return pred_[idx] == node_idx_t::invalid()
+    std::optional<node> pred(node const n) const noexcept {
+      auto const s = s_[get_index(n)];
+      return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{.n_ = pred_[idx],
-                                      .type_ = to_node_type(pred_type_[idx]),
-                                      .lvl_ = pred_lvl_[idx],
-                                      .dir_ = to_dir(pred_dir_[idx]),
-                                      .way_ = pred_way_[idx]}};
+                 : std::optional{node{.n_ = s.pred_,
+                                      .type_ = to_node_type(s.pred_type_),
+                                      .lvl_ = s.pred_lvl_,
+                                      .dir_ = to_dir(s.pred_dir_),
+                                      .way_ = s.pred_way_}};
     }
 
-    constexpr cost_t cost(node const n) const noexcept {
-      return cost_[get_index(n)];
-    }
+    cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
     constexpr duration_t duration(node const n) const noexcept {
       return duration_from_cost(cost(n));
     }
 
-    constexpr bool update(label const,
-                          node const n,
-                          cost_t const c,
-                          node const pred,
-                          duration_t const) noexcept {
-      auto const idx = get_index(n);
-      if (c < cost_[idx]) {
-        cost_[idx] = c;
-        pred_[idx] = pred.n_;
-        pred_lvl_[idx] = pred.lvl_;
-        pred_type_[idx] = to_bool(pred.type_);
-        pred_way_[idx] = pred.way_;
-        pred_dir_[idx] = to_bool(pred.dir_);
-        return true;
+    bool update(label const,
+                node const n,
+                cost_t const c,
+                node const pred,
+                duration_t const,
+                ways::routing const& w,
+                entry_storage_arena& a) {
+      auto& s = s_.slot(get_index(n), w, n.n_, a);
+      if (c >= s.cost_) {
+        return false;
       }
-      return false;
+      s.cost_ = c;
+      s.pred_ = pred.n_;
+      s.pred_lvl_ = pred.lvl_;
+      s.pred_type_ = to_bool(pred.type_);
+      s.pred_way_ = pred.way_;
+      s.pred_dir_ = to_bool(pred.dir_);
+      return true;
     }
 
     static constexpr std::size_t get_index(node const n) {
-      return n.is_foot_node()
-                 ? 0U
-                 : 1U + (n.dir_ == direction::kForward ? 0U : 1U) * kMaxWays +
-                       n.way_;
+      return n.is_foot_node() ? 0U : storage_t::index(n.way_, n.dir_);
     }
 
     static constexpr direction to_dir(bool const b) {
@@ -208,13 +207,7 @@ struct car_parking {
 
     void write(node, path&) const {}
 
-    std::array<node_idx_t, kN> pred_;
-    std::array<cost_t, kN> cost_;
-    std::array<way_pos_t, kN> pred_way_;
-    std::array<level_t, kN> pred_lvl_;
-    std::bitset<kN> pred_dir_;
-    std::bitset<kN> pred_type_;
-    std::bitset<kN> pred_parking_;
+    storage_t s_;
   };
 
   struct hash {

--- a/include/osr/routing/profiles/car_sharing.h
+++ b/include/osr/routing/profiles/car_sharing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+
 #include <array>
 #include <optional>
 #include <string_view>
@@ -8,15 +9,15 @@
 
 #include "boost/json.hpp"
 
-#include "utl/helpers/algorithm.h"
-
 #include "osr/elevation_storage.h"
 #include "osr/routing/additional_edge.h"
+#include "osr/routing/entry_storage.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/car.h"
 #include "osr/routing/profiles/foot.h"
 #include "osr/routing/sharing_data.h"
+#include "osr/routing/tracking.h"
 #include "osr/ways.h"
 
 namespace osr {
@@ -228,55 +229,59 @@ struct car_sharing {
 #endif
   };
 
+  struct slot {
+    node_idx_t pred_{node_idx_t::invalid()};
+    cost_t cost_{kInfeasible};
+    level_t pred_lvl_{kNoLevel};
+    node_type pred_type_{node_type::kInvalid};
+    way_pos_t pred_way_{0U};
+    bool pred_dir_{false};
+    OSR_NO_UNIQUE_ADDRESS Tracking tracking_{};
+  };
+
   struct entry {
-    static constexpr auto const kMaxWays = way_pos_t{16U};
-    static constexpr auto const kN =
-        kMaxWays * 2U + 2 /* FWD+BWD + initial foot + trailing foot */;
+    using slot_t = slot;
 
-    entry() {
-      utl::fill(pred_, node_idx_t::invalid());
-      utl::fill(cost_, kInfeasible);
-      utl::fill(pred_lvl_, kNoLevel);
-      utl::fill(pred_way_, way_pos_t{0});
-      utl::fill(pred_type_, node_type::kInvalid);
-    }
+    using storage_t =
+        entry_storage<slot_t, 2U>;  // 2 extra: initial + trailing foot
+    static constexpr auto const kN = storage_t::kN;
 
-    constexpr std::optional<node> pred(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return pred_[idx] == node_idx_t::invalid()
+    std::optional<node> pred(node const n) const noexcept {
+      auto const s = s_[get_index(n)];
+      return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{.n_ = pred_[idx],
-                                      .type_ = pred_type_[idx],
-                                      .lvl_ = pred_lvl_[idx],
-                                      .dir_ = to_dir(pred_dir_[idx]),
-                                      .way_ = pred_way_[idx]}};
+                 : std::optional{node{.n_ = s.pred_,
+                                      .type_ = s.pred_type_,
+                                      .lvl_ = s.pred_lvl_,
+                                      .dir_ = to_dir(s.pred_dir_),
+                                      .way_ = s.pred_way_}};
     }
 
-    constexpr cost_t cost(node const n) const noexcept {
-      return cost_[get_index(n)];
-    }
+    cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
     constexpr duration_t duration(node const n) const noexcept {
       return duration_from_cost(cost(n));
     }
 
-    constexpr bool update(label const& l,
-                          node const n,
-                          cost_t const c,
-                          node const pred,
-                          duration_t const) noexcept {
-      auto const idx = get_index(n);
-      if (c < cost_[idx]) {
-        cost_[idx] = c;
-        pred_[idx] = pred.n_;
-        pred_lvl_[idx] = pred.lvl_;
-        pred_way_[idx] = pred.way_;
-        pred_dir_[idx] = to_bool(pred.dir_);
-        pred_type_[idx] = pred.type_;
-        tracking_[idx] = l.tracking_;
-        return true;
+    bool update(label const& l,
+                node const n,
+                cost_t const c,
+                node const pred,
+                duration_t const,
+                ways::routing const& w,
+                entry_storage_arena& a) {
+      auto& s = s_.slot(get_index(n), w, n.n_, a);
+      if (c >= s.cost_) {
+        return false;
       }
-      return false;
+      s.cost_ = c;
+      s.pred_ = pred.n_;
+      s.pred_lvl_ = pred.lvl_;
+      s.pred_way_ = pred.way_;
+      s.pred_dir_ = to_bool(pred.dir_);
+      s.pred_type_ = pred.type_;
+      s.tracking_ = l.tracking_;
+      return true;
     }
 
     static constexpr std::size_t get_index(node const n) {
@@ -284,7 +289,7 @@ struct car_sharing {
         case node_type::kInitialFoot: return 0U;
         case node_type::kTrailingFoot: return 1U;
         default:  // node_type::kRental
-          return 2U + (n.dir_ == direction::kForward ? 0U : kMaxWays) + n.way_;
+          return storage_t::index(n.way_, n.dir_);
       }
     }
 
@@ -297,21 +302,10 @@ struct car_sharing {
     }
 
     void write(node const n, path& p) const {
-      tracking_[get_index(n)].write(p);
+      s_[get_index(n)].tracking_.write(p);
     }
 
-    std::array<node_idx_t, kN> pred_{};
-    std::array<cost_t, kN> cost_{};
-    std::array<level_t, kN> pred_lvl_{};
-    std::array<way_pos_t, kN> pred_way_{};
-    std::bitset<kN> pred_dir_{};
-    std::array<node_type, kN> pred_type_{};
-#ifdef _MSC_VER
-    [[no_unique_address]] [[msvc::no_unique_address]] std::array<Tracking, kN>
-        tracking_;
-#else
-    [[no_unique_address]] std::array<Tracking, kN> tracking_;
-#endif
+    storage_t s_;
   };
 
   static footp::node to_foot(node const n) {

--- a/include/osr/routing/profiles/common.h
+++ b/include/osr/routing/profiles/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+
 #include <optional>
 #include <utility>
 

--- a/include/osr/routing/profiles/ferry.h
+++ b/include/osr/routing/profiles/ferry.h
@@ -9,6 +9,7 @@
 #include "utl/helpers/algorithm.h"
 
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/common.h"
@@ -92,7 +93,9 @@ struct ferry {
                           node const,
                           cost_t const c,
                           node const pred,
-                          duration_t const) noexcept {
+                          duration_t const,
+                          ways::routing const&,
+                          entry_storage_arena&) noexcept {
       if (c < cost_) {
         cost_ = c;
         pred_ = pred.n_;

--- a/include/osr/routing/profiles/foot.h
+++ b/include/osr/routing/profiles/foot.h
@@ -5,6 +5,7 @@
 #include "utl/for_each_bit_set.h"
 
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage_arena.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/tracking.h"
@@ -78,11 +79,7 @@ struct foot {
     node_idx_t n_;
     cost_t cost_;
     level_t lvl_;
-#ifdef _MSC_VER
-    [[no_unique_address]] [[msvc::no_unique_address]] Tracking tracking_;
-#else
-    [[no_unique_address]] Tracking tracking_;
-#endif
+    OSR_NO_UNIQUE_ADDRESS Tracking tracking_;
   };
 
   struct entry {
@@ -101,7 +98,9 @@ struct foot {
                           node,
                           cost_t const c,
                           node const pred,
-                          duration_t const) noexcept {
+                          duration_t const,
+                          ways::routing const&,
+                          entry_storage_arena&) noexcept {
       if (c < cost_) {
         tracking_ = l.tracking_;
         cost_ = c;
@@ -117,11 +116,7 @@ struct foot {
     node_idx_t pred_{node_idx_t::invalid()};
     cost_t cost_{kInfeasible};
     level_t pred_lvl_;
-#ifdef _MSC_VER
-    [[no_unique_address]] [[msvc::no_unique_address]] Tracking tracking_;
-#else
-    [[no_unique_address]] Tracking tracking_;
-#endif
+    OSR_NO_UNIQUE_ADDRESS Tracking tracking_;
   };
 
   struct hash {

--- a/include/osr/routing/profiles/hgv.h
+++ b/include/osr/routing/profiles/hgv.h
@@ -3,7 +3,6 @@
 #include <cmath>
 
 #include <algorithm>
-#include <bitset>
 #include <limits>
 #include <optional>
 #include <tuple>
@@ -16,6 +15,7 @@
 
 #include "osr/elevation_storage.h"
 #include "osr/routing/conditional.h"
+#include "osr/routing/entry_storage.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/common.h"
@@ -26,6 +26,14 @@
 namespace osr {
 
 struct sharing_data;
+
+struct hgv_slot {
+  node_idx_t pred_{node_idx_t::invalid()};
+  cost_t cost_{kInfeasible};
+  way_pos_t pred_way_{0U};
+  bool pred_dir_{false};
+  duration_t duration_{kMaxDuration};
+};
 
 struct hgv {
   static constexpr auto const kName = "hgv";
@@ -123,66 +131,64 @@ struct hgv {
   };
 
   struct entry {
-    static constexpr auto const kMaxWays = way_pos_t{16U};
-    static constexpr auto const kN = kMaxWays * 2U /* FWD+BWD */;
+    using slot_t = hgv_slot;
 
-    entry() {
-      utl::fill(pred_, node_idx_t::invalid());
-      utl::fill(cost_, kInfeasible);
-      utl::fill(duration_, kMaxDuration);
-    }
+    using storage_t = entry_storage<slot_t, 0U>;
+    static constexpr auto const kN = storage_t::kN /* FWD+BWD */;
 
-    constexpr std::optional<node> pred(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return pred_[idx] == node_idx_t::invalid()
+    std::optional<node> pred(node const n) const noexcept {
+      auto const s = s_[get_index(n)];
+      return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{pred_[idx], pred_way_[idx],
-                                      to_dir(pred_dir_[idx])}};
+                 : std::optional{
+                       node{s.pred_, s.pred_way_, to_dir(s.pred_dir_)}};
     }
 
-    constexpr cost_t cost(node const n) const noexcept {
-      return cost_[get_index(n)];
+    cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
+
+    duration_t duration(node const n) const noexcept {
+      return s_[get_index(n)].duration_;
     }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_[get_index(n)];
+    bool update(label const& l,
+                node const n,
+                cost_t const c,
+                node const pred,
+                ways::routing const& w,
+                entry_storage_arena& a) {
+      return update(l, n, c, pred, duration_from_cost(c), w, a);
     }
 
-    constexpr bool update(label const& l,
-                          node const n,
-                          cost_t const c,
-                          node const pred) noexcept {
-      return update(l, n, c, pred, duration_from_cost(c));
-    }
-
-    constexpr bool update(label const&,
-                          node const n,
-                          cost_t const c,
-                          node const pred,
-                          duration_t const duration) noexcept {
+    bool update(label const&,
+                node const n,
+                cost_t const c,
+                node const pred,
+                duration_t const duration,
+                ways::routing const& w,
+                entry_storage_arena& a) {
       n_ = n.n_;
-      auto const idx = get_index(n);
-      if (c < cost_[idx] || (c == cost_[idx] && duration < duration_[idx])) {
-        cost_[idx] = c;
-        duration_[idx] = duration;
-        pred_[idx] = pred.n_;
-        pred_way_[idx] = pred.way_;
-        pred_dir_[idx] = to_bool(pred.dir_);
-        return true;
+      auto& s = s_.slot(get_index(n), w, n.n_, a);
+      if (!(c < s.cost_ || (c == s.cost_ && duration < s.duration_))) {
+        return false;
       }
-      return false;
+      s.cost_ = c;
+      s.duration_ = duration;
+      s.pred_ = pred.n_;
+      s.pred_way_ = pred.way_;
+      s.pred_dir_ = to_bool(pred.dir_);
+      return true;
     }
 
     void write(node, path&) const {}
 
     static constexpr node get_node(node_idx_t const n,
                                    std::size_t const index) {
-      return node{n, static_cast<way_pos_t>(index % kMaxWays),
-                  to_dir((index / kMaxWays) != 0U)};
+      return node{n, static_cast<way_pos_t>(index / 2U),
+                  to_dir((index % 2U) != 0U)};
     }
 
     static constexpr std::size_t get_index(node const n) {
-      return (n.dir_ == direction::kForward ? 0U : 1U) * kMaxWays + n.way_;
+      return storage_t::index(n.way_, n.dir_);
     }
 
     static constexpr direction to_dir(bool const b) {
@@ -193,11 +199,7 @@ struct hgv {
       return d == direction::kForward ? false : true;
     }
 
-    std::array<node_idx_t, kN> pred_;
-    std::array<way_pos_t, kN> pred_way_;
-    std::bitset<kN> pred_dir_;
-    std::array<cost_t, kN> cost_;
-    std::array<duration_t, kN> duration_;
+    storage_t s_;
     node_idx_t n_{node_idx_t::invalid()};
   };
 

--- a/include/osr/routing/profiles/railway.h
+++ b/include/osr/routing/profiles/railway.h
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <chrono>
-#include <bitset>
 #include <optional>
 
 #include "boost/json/object.hpp"
 
-#include "utl/helpers/algorithm.h"
-
 #include "osr/elevation_storage.h"
+#include "osr/routing/entry_storage.h"
 #include "osr/routing/mode.h"
 #include "osr/routing/path.h"
 #include "osr/routing/profiles/common.h"
@@ -18,6 +16,13 @@
 namespace osr {
 
 struct sharing_data;
+
+struct railway_slot {
+  node_idx_t pred_{node_idx_t::invalid()};
+  cost_t cost_{kInfeasible};
+  way_pos_t pred_way_{0U};
+  bool pred_dir_{false};
+};
 
 struct railway {
   static constexpr auto const kName = "railway";
@@ -105,57 +110,53 @@ struct railway {
   };
 
   struct entry {
-    static constexpr auto const kMaxWays = way_pos_t{16U};
-    static constexpr auto const kN = kMaxWays * 2U /* FWD+BWD */;
+    using slot_t = railway_slot;
 
-    entry() {
-      utl::fill(cost_, kInfeasible);
-      utl::fill(pred_, node_idx_t::invalid());
-      utl::fill(pred_way_, way_pos_t{0});
-    }
+    using storage_t = entry_storage<slot_t, 0U>;
+    static constexpr auto const kN = storage_t::kN /* FWD+BWD */;
 
-    constexpr std::optional<node> pred(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return pred_[idx] == node_idx_t::invalid()
+    std::optional<node> pred(node const n) const noexcept {
+      auto const s = s_[get_index(n)];
+      return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{pred_[idx], pred_way_[idx],
-                                      to_dir(pred_dir_[idx])}};
+                 : std::optional{
+                       node{s.pred_, s.pred_way_, to_dir(s.pred_dir_)}};
     }
 
-    constexpr cost_t cost(node const n) const noexcept {
-      return cost_[get_index(n)];
-    }
+    cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
     constexpr duration_t duration(node const n) const noexcept {
       return duration_from_cost(cost(n));
     }
 
-    constexpr bool update(label const&,
-                          node const n,
-                          cost_t const c,
-                          node const pred,
-                          duration_t const) noexcept {
-      auto const idx = get_index(n);
-      if (c < cost_[idx]) {
-        cost_[idx] = c;
-        pred_[idx] = pred.n_;
-        pred_way_[idx] = pred.way_;
-        pred_dir_[idx] = to_bool(pred.dir_);
-        return true;
+    bool update(label const&,
+                node const n,
+                cost_t const c,
+                node const pred,
+                duration_t const,
+                ways::routing const& w,
+                entry_storage_arena& a) {
+      auto& s = s_.slot(get_index(n), w, n.n_, a);
+      if (c >= s.cost_) {
+        return false;
       }
-      return false;
+      s.cost_ = c;
+      s.pred_ = pred.n_;
+      s.pred_way_ = pred.way_;
+      s.pred_dir_ = to_bool(pred.dir_);
+      return true;
     }
 
     void write(node, path&) const {}
 
     static constexpr node get_node(node_idx_t const n,
                                    std::size_t const index) {
-      return node{n, static_cast<way_pos_t>(index % kMaxWays),
-                  to_dir((index / kMaxWays) != 0U)};
+      return node{n, static_cast<way_pos_t>(index / 2U),
+                  to_dir((index % 2U) != 0U)};
     }
 
     static constexpr std::size_t get_index(node const n) {
-      return (n.dir_ == direction::kForward ? 0U : 1U) * kMaxWays + n.way_;
+      return storage_t::index(n.way_, n.dir_);
     }
 
     static constexpr direction to_dir(bool const b) {
@@ -166,10 +167,7 @@ struct railway {
       return d == direction::kForward ? false : true;
     }
 
-    std::array<node_idx_t, kN> pred_;
-    std::array<way_pos_t, kN> pred_way_;
-    std::bitset<kN> pred_dir_;
-    std::array<cost_t, kN> cost_;
+    storage_t s_;
   };
 
   struct hash {

--- a/include/osr/routing/sharing_data.h
+++ b/include/osr/routing/sharing_data.h
@@ -4,11 +4,22 @@
 
 #include "geo/latlng.h"
 
+#include "utl/verify.h"
+
 #include "osr/routing/additional_edge.h"
 #include "osr/types.h"
 #include "osr/ways.h"
 
 namespace osr {
+
+inline void verify_additional_edge_count(
+    hash_map<node_idx_t, std::vector<additional_edge>> const& edges) {
+  for (auto const& [node, node_edges] : edges) {
+    utl::verify(node_edges.size() <= kMaxWaysPerNode,
+                "node {} has {} additional edges, maximum is {}", node,
+                node_edges.size(), kMaxWaysPerNode);
+  }
+}
 
 struct sharing_data {
   geo::latlng get_additional_node_coordinates(node_idx_t const n) const {

--- a/include/osr/routing/tracking.h
+++ b/include/osr/routing/tracking.h
@@ -3,6 +3,12 @@
 #include "osr/routing/path.h"
 #include "osr/ways.h"
 
+#ifdef _MSC_VER
+#define OSR_NO_UNIQUE_ADDRESS [[no_unique_address]] [[msvc::no_unique_address]]
+#else
+#define OSR_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
 namespace osr {
 
 struct elevator_tracking {

--- a/include/osr/types.h
+++ b/include/osr/types.h
@@ -9,7 +9,6 @@
 #include <optional>
 
 #include "ankerl/cista_adapter.h"
-
 #include "cista/containers/bitvec.h"
 #include "cista/containers/mmap_vec.h"
 #include "cista/containers/nvec.h"
@@ -18,7 +17,6 @@
 #include "cista/containers/vector.h"
 #include "cista/containers/vecvec.h"
 #include "cista/strong.h"
-
 #include "utl/for_each_bit_set.h"
 
 namespace osr {
@@ -171,6 +169,9 @@ using elevation_monotonic_t =
     cista::strong<std::uint16_t, struct elevation_monotonic_>;
 
 using way_pos_t = std::uint8_t;
+
+constexpr auto const kMaxWaysPerNode = way_pos_t{16U};
+constexpr auto const kInlineWaysPerNode = way_pos_t{2U};
 
 using cost_t = std::uint32_t;
 using duration_t = std::chrono::duration<std::uint16_t>;  // sec -> max ~18h

--- a/src/map_matching.cc
+++ b/src/map_matching.cc
@@ -362,6 +362,7 @@ matched_route map_match(
       return min_start_cost;
     };
 
+    verify_additional_edge_count(seg.additional_edges_);
     seg.sharing_ = std::make_unique<sharing_data>(sharing_data{
         .additional_node_offset_ = additional_node_offset,
         .additional_node_coordinates_ = additional_node_coordinates,

--- a/src/ways.cc
+++ b/src/ways.cc
@@ -309,6 +309,9 @@ void ways::connect_ways() {
     // Reserve node_ways_ / node_in_way_idx_ for each node.
     for (auto n = std::size_t{0U}; n != n_nodes; ++n) {
       auto const size = count[n].exchange(0U, std::memory_order_relaxed);
+      utl::verify(size <= kMaxWaysPerNode,
+                  "node {} (osm={}) has {} ways, maximum is {}", n,
+                  node_to_osm_[node_idx_t{n}], size, kMaxWaysPerNode);
       r_->node_ways_.add_back_sized(size);
       r_->node_in_way_idx_.add_back_sized(size);
     }

--- a/test/entry_storage_test.cc
+++ b/test/entry_storage_test.cc
@@ -51,11 +51,11 @@ TEST(entry_storage, promotion_preserves_inline_and_extra_slots) {
   for (auto i = std::size_t{0U}; i != storage_t::kInlineN; ++i) {
     s.slot(i, w, kNode, arena).value_ = static_cast<std::uint32_t>(100U + i);
   }
-  ASSERT_EQ(nullptr, s.overflow_);
+  ASSERT_FALSE(s.is_overflow());
 
   auto const promoting = storage_t::index(2U, direction::kForward);
   s.slot(promoting, w, kNode, arena).value_ = 200U;
-  ASSERT_NE(nullptr, s.overflow_);
+  ASSERT_TRUE(s.is_overflow());
 
   for (auto i = std::size_t{0U}; i != storage_t::kInlineN; ++i) {
     EXPECT_EQ(100U + i, s[i].value_);

--- a/test/entry_storage_test.cc
+++ b/test/entry_storage_test.cc
@@ -1,0 +1,146 @@
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+#include <initializer_list>
+#include <limits>
+#include <vector>
+
+#include "osr/routing/entry_storage.h"
+#include "osr/routing/entry_storage_arena.h"
+#include "osr/ways.h"
+
+namespace osr {
+
+namespace {
+
+constexpr auto const kUnset = std::numeric_limits<std::uint32_t>::max();
+constexpr auto const kNode = node_idx_t{0U};
+
+struct test_slot {
+  std::uint32_t value_{kUnset};
+};
+
+using storage_t = entry_storage<test_slot, 2U>;
+
+ways::routing make_routing(
+    std::initializer_list<std::size_t> const ways_per_node) {
+  auto w = ways::routing{};
+  for (auto const n : ways_per_node) {
+    w.node_ways_.add_back_sized(n);
+  }
+  return w;
+}
+
+}  // namespace
+
+TEST(entry_storage, unwritten_slots_read_as_unset) {
+  auto const s = storage_t{};
+
+  EXPECT_EQ(kUnset, s[storage_t::kInlineN - 1U].value_);
+  EXPECT_EQ(kUnset, s[storage_t::kInlineN].value_);
+  EXPECT_EQ(kUnset, s[storage_t::kN - 1U].value_);
+}
+
+TEST(entry_storage, promotion_preserves_inline_and_extra_slots) {
+  auto const w = make_routing({3U});
+  auto arena = entry_storage_arena{};
+  auto s = storage_t{};
+
+  for (auto i = std::size_t{0U}; i != storage_t::kInlineN; ++i) {
+    s.slot(i, w, kNode, arena).value_ = static_cast<std::uint32_t>(100U + i);
+  }
+  ASSERT_EQ(nullptr, s.overflow_);
+
+  auto const promoting = storage_t::index(2U, direction::kForward);
+  s.slot(promoting, w, kNode, arena).value_ = 200U;
+  ASSERT_NE(nullptr, s.overflow_);
+
+  for (auto i = std::size_t{0U}; i != storage_t::kInlineN; ++i) {
+    EXPECT_EQ(100U + i, s[i].value_);
+  }
+  EXPECT_EQ(200U, s[promoting].value_);
+  EXPECT_EQ(kUnset, s[storage_t::index(2U, direction::kBackward)].value_);
+}
+
+TEST(entry_storage, overflow_block_matches_node_degree) {
+  auto const w = make_routing({3U});
+  auto arena = entry_storage_arena{};
+  auto s = storage_t{};
+
+  s.slot(storage_t::index(2U, direction::kForward), w, kNode, arena).value_ =
+      1U;
+
+  EXPECT_EQ(storage_t::slot_count(3U) * sizeof(storage_t::slot_t),
+            arena.offset_);
+}
+
+TEST(entry_storage, maximum_degree_exposes_every_slot) {
+  auto const w = make_routing({kMaxWaysPerNode});
+  auto arena = entry_storage_arena{};
+  auto s = storage_t{};
+
+  for (auto i = std::size_t{0U}; i != storage_t::kN; ++i) {
+    s.slot(i, w, kNode, arena).value_ = static_cast<std::uint32_t>(i + 1U);
+  }
+  for (auto i = std::size_t{0U}; i != storage_t::kN; ++i) {
+    EXPECT_EQ(i + 1U, s[i].value_);
+  }
+  EXPECT_EQ(storage_t::kN * sizeof(storage_t::slot_t), arena.offset_);
+}
+
+TEST(entry_storage, additional_nodes_use_maximum_size) {
+  auto const w = make_routing({1U});
+  auto arena = entry_storage_arena{};
+  auto s = storage_t{};
+  auto const additional_node = node_idx_t{1U};
+
+  s.slot(storage_t::kN - 1U, w, additional_node, arena).value_ = 42U;
+
+  EXPECT_EQ(42U, s[storage_t::kN - 1U].value_);
+  EXPECT_EQ(storage_t::kN * sizeof(storage_t::slot_t), arena.offset_);
+}
+
+TEST(entry_storage_arena, accounts_for_alignment_padding) {
+  auto arena = entry_storage_arena{};
+
+  auto* const first = static_cast<std::byte*>(arena.allocate(1U, 1U));
+  auto* const aligned = static_cast<std::byte*>(
+      arena.allocate(sizeof(std::uint64_t), alignof(std::uint64_t)));
+  auto* const after = static_cast<std::byte*>(arena.allocate(1U, 1U));
+
+  EXPECT_EQ(0U,
+            reinterpret_cast<std::uintptr_t>(aligned) % alignof(std::uint64_t));
+  EXPECT_EQ(first + alignof(std::uint64_t), aligned);
+  EXPECT_EQ(aligned + sizeof(std::uint64_t), after);
+}
+
+TEST(entry_storage_arena, reuses_chunks_after_reset) {
+  struct block {
+    std::array<std::uint64_t, 512U> data_{};
+  };
+  static_assert(entry_storage_arena::kChunkSize % sizeof(block) == 0U);
+
+  auto arena = entry_storage_arena{};
+  auto const per_chunk = entry_storage_arena::kChunkSize / sizeof(block);
+  auto const n_blocks = 2U * per_chunk + 1U;
+  auto first = std::vector<block*>{};
+  auto second = std::vector<block*>{};
+
+  for (auto i = std::size_t{0U}; i != n_blocks; ++i) {
+    auto* const b = arena.create_array<block>(1U);
+    b->data_[0] = i + 1U;
+    first.push_back(b);
+  }
+
+  arena.reset();
+  for (auto i = std::size_t{0U}; i != n_blocks; ++i) {
+    second.push_back(arena.create_array<block>(1U));
+  }
+
+  EXPECT_EQ(first, second);
+  EXPECT_EQ(0U, second.back()->data_[0]);
+}
+
+}  // namespace osr

--- a/test/sharing_routing_test.cc
+++ b/test/sharing_routing_test.cc
@@ -68,6 +68,7 @@ struct test_sharing_data {
   }
 
   sharing_data view(ways const& w) const {
+    verify_additional_edge_count(additional_edges_);
     return {.start_allowed_ = &start_allowed_,
             .end_allowed_ = &end_allowed_,
             .through_allowed_ = &through_allowed_,


### PR DESCRIPTION
Some routing profiles (car, car_parking, car_sharing, hgv, railway) have two slots for each way at a node in their routing entries (forward + backward direction, sharing/parking also additional slots for foot states).
Previously, we always reserved storage for 16 ways per node, even though most nodes have much fewer ways.

Here's the ways per node distribution for Germany:

```
    0 ways:       344470 nodes  (  1.6357%)  cumulative:   1.6357%
    1 ways:       681601 nodes  (  3.2365%)  cumulative:   4.8722%
    2 ways:     16473426 nodes  ( 78.2217%)  cumulative:  83.0939%
    3 ways:      2988014 nodes  ( 14.1882%)  cumulative:  97.2820%
    4 ways:       529384 nodes  (  2.5137%)  cumulative:  99.7957%
    5 ways:        37848 nodes  (  0.1797%)  cumulative:  99.9755%
    6 ways:         4612 nodes  (  0.0219%)  cumulative:  99.9974%
    7 ways:          444 nodes  (  0.0021%)  cumulative:  99.9995%
    8 ways:           90 nodes  (  0.0004%)  cumulative:  99.9999%
    9 ways:           12 nodes  (  0.0001%)  cumulative:  99.9999%
   10 ways:            4 nodes  (  0.0000%)  cumulative: 100.0000%
   11 ways:            4 nodes  (  0.0000%)  cumulative: 100.0000%
   12 ways:            1 nodes  (  0.0000%)  cumulative: 100.0000%
   13 ways:            2 nodes  (  0.0000%)  cumulative: 100.0000%
  avg ways/node: 2.13348
```

This PR changes the entry storage for these profiles so that only a small number of slots are stored inline (currently 2). For nodes that need more, overflow storage is allocated using a bump allocator.

This reduces the memory usage for routing queries using these profiles by about 65-70%.
The storage layout changes also leave enough unused padding space so that duration tracking can be added for free for these profiles (each slot needs 12 bytes either way) (see #136 ).

Example benchmark, random queries in Germany (4w/3w/2w = number of inline ways):

## Peak live memory — duration tracking OFF (per query, median)

| benchmark | before | 4w | 3w | 2w |
|---|---:|---:|---:|---:|
| car ≤10 km | 7.1 MiB | 3.2 (−54.9%) | 2.7 (−61.9%) | **1.9 (−73.3%)** |
| car ≤50 km | 108 MiB | 44.2 (−59.1%) | 37.0 (−65.7%) | **30.9 (−71.4%)** |
| car ≤100 km | 214 MiB | 91.6 (−57.1%) | 77.5 (−63.7%) | **66.0 (−69.1%)** |
| hgv ≤50 km | 131 MiB | 56.5 (−57.0%) | 47.9 (−63.5%) | **40.7 (−69.0%)** |

## Total allocation — duration tracking OFF (per query, median)

| benchmark | before | 4w | 3w | 2w |
|---|---:|---:|---:|---:|
| car ≤10 km | 10.9 MiB | 4.6 (−57.7%) | 4.0 (−63.4%) | **3.2 (−70.8%)** |
| car ≤50 km | 175 MiB | 73.7 (−57.9%) | 62.2 (−64.5%) | **51.2 (−70.7%)** |
| car ≤100 km | 351 MiB | 154 (−56.2%) | 130 (−62.8%) | **109 (−68.8%)** |
| hgv ≤50 km | 187 MiB | 86.7 (−53.5%) | 75.1 (−59.7%) | **65.0 (−65.2%)** |

Runtime performance is also slightly improved:

| benchmark | before | 4w | 3w | 2w |
|---|---:|---:|---:|---:|
| car ≤10 km | 7.0 ms | 5.6 (−19.2%) | 5.6 (−19.4%) | 6.0 (−13.0%) |
| car ≤50 km | 158.5 ms | 142.6 (−10.1%) | 140.5 (−11.4%) | 133.5 (−15.8%) |
| car ≤100 km | 476.7 ms | 410.1 (−14.0%) | 425.3 (−10.8%) | 415.1 (−12.9%) |
| hgv ≤50 km | 278.4 ms | 259.1 (−6.9%) | 256.6 (−7.8%) | 271.2 (−2.6%) |



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>