### PR TITLE
Track duration in all routing profiles

### DIFF
--- a/include/osr/routing/astar.h
+++ b/include/osr/routing/astar.h
@@ -77,9 +77,9 @@ struct astar {
     auto const& w = params_.w();
     auto const heur = heuristic(params_.profile_, w, params_.sharing(),
                                 l.get_node().get_node());
-    if (cost_[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                             node::invalid(), duration, *w.r_,
-                                             arena_)) {
+    if (cost_[l.get_node().get_key()].update(
+            l, l.get_node(), {.cost_ = l.cost(), .duration_ = duration},
+            node::invalid(), *w.r_, arena_)) {
       auto const cost_with_heur = l.cost() + heur;
       if constexpr (kDebug) {
         std::cout << "START ";
@@ -233,17 +233,19 @@ struct astar {
               max_reached_ = true;
               return;
             }
-            auto const total_duration = clamp_add_duration(
-                cost_.at(curr_node.get_key()).duration(curr_node), duration);
+            auto const next_cd = cost_and_duration{
+                .cost_ = static_cast<cost_t>(total),
+                .duration_ = clamp_add_duration(
+                    cost_.at(curr_node.get_key()).duration(curr_node),
+                    duration)};
             auto const updated = [&]() {
               if (heur >= max) {
                 return false;
               }
               auto next = label{neighbor, static_cast<cost_t>(heur)};
               next.track(l, r, way, neighbor.get_node(), track);
-              if (!cost_[neighbor.get_key()].update(
-                      next, neighbor, static_cast<cost_t>(total), curr_node,
-                      total_duration, r, arena_)) {
+              if (!cost_[neighbor.get_key()].update(next, neighbor, next_cd,
+                                                    curr_node, r, arena_)) {
                 return false;
               }
               pq_.push(std::move(next));

--- a/include/osr/routing/astar.h
+++ b/include/osr/routing/astar.h
@@ -11,7 +11,10 @@
 #include "utl/to_vec.h"
 #include "utl/verify.h"
 
+#include "geo/constants.h"
+
 #include "osr/elevation_storage.h"
+#include "osr/location.h"
 #include "osr/routing/additional_edge.h"
 #include "osr/routing/dial.h"
 #include "osr/routing/entry_storage_arena.h"
@@ -51,6 +54,7 @@ struct astar {
     arena_.reset();
     max_reached_ = false;
     destinations_.clear();
+    settled_.clear();
     remaining_destinations_ = 0U;
     early_termination_max_cost_ = kInfeasible;
     terminated_early_max_cost_ = false;
@@ -100,6 +104,8 @@ struct astar {
     auto const* sharing = params_.sharing();
     auto it = std::lower_bound(begin(destinations_), end(destinations_), n);
     if (it == end(destinations_) || *it != n) {
+      settled_.insert(begin(settled_) + std::distance(begin(destinations_), it),
+                      false);
       destinations_.insert(it, n);
       ++remaining_destinations_;
 
@@ -120,6 +126,25 @@ struct astar {
         dest_radius_ = std::max(dest_radius_, geo::distance(dest_centroid_, p));
       }
     }
+  }
+
+  bool settle_destination(node const n) {
+    auto const it =
+        std::lower_bound(begin(destinations_), end(destinations_), n);
+    if (it == end(destinations_) || *it != n) {
+      return false;
+    }
+    auto const idx =
+        static_cast<std::size_t>(std::distance(begin(destinations_), it));
+    if (settled_[idx]) {
+      // equal-cost labels with shorter durations can re-enter the queue, so the
+      // same destination can be popped more than once and must only be counted
+      // once
+      return false;
+    }
+    settled_[idx] = true;
+    --remaining_destinations_;
+    return true;
   }
 
   cost_t get_cost(node const n) const {
@@ -150,9 +175,7 @@ struct astar {
       }
 
       if constexpr (EarlyTermination) {
-        if (std::find(begin(destinations_), end(destinations_), curr_node) !=
-            end(destinations_)) {
-          --remaining_destinations_;
+        if (settle_destination(curr_node)) {
           early_termination_max_cost_ = std::min(
               early_termination_max_cost_,
               static_cast<cost_t>(std::min(
@@ -280,6 +303,7 @@ struct astar {
   bool max_reached_{};
 
   std::vector<node> destinations_;
+  std::vector<bool> settled_;
   std::size_t remaining_destinations_{0U};
   cost_t early_termination_max_cost_{kInfeasible};
   bool terminated_early_max_cost_{false};

--- a/include/osr/routing/astar.h
+++ b/include/osr/routing/astar.h
@@ -57,6 +57,7 @@ struct astar {
     settled_.clear();
     remaining_destinations_ = 0U;
     early_termination_max_cost_ = kInfeasible;
+    all_settled_key_ = kInfeasible;
     terminated_early_max_cost_ = false;
     auto const& from = params_.start_loc_;
     auto const& to = params_.end_loc_;
@@ -175,22 +176,32 @@ struct astar {
       }
 
       if constexpr (EarlyTermination) {
-        if (settle_destination(curr_node)) {
-          early_termination_max_cost_ = std::min(
-              early_termination_max_cost_,
-              static_cast<cost_t>(std::min(
-                  {static_cast<std::uint64_t>(curr_cost) * 2 +
-                       static_cast<std::uint64_t>(P::upper_bound_heuristic(
-                           params, std::min(beeline_distance_, 1000.0))),
-                   static_cast<std::uint64_t>(
-                       curr_cost + P::upper_bound_heuristic(params, 10000U)),
-                   static_cast<std::uint64_t>(kInfeasible - 1U)})));
-          if (remaining_destinations_ == 0U) {
+        // Same duration tie break as in dijkstra, but the queue is keyed on
+        // l.cost() = curr_cost + curr_heur, so we can only terminate once
+        // that bucket is empty.
+        // Unlike in dijkstra, 0-cost edges aren't needed here: an edge the
+        // heuristic is exact on also puts both of its nodes in one bucket.
+        if (all_settled_key_ == kInfeasible) {
+          if (settle_destination(curr_node)) {
+            early_termination_max_cost_ = std::min(
+                early_termination_max_cost_,
+                static_cast<cost_t>(std::min(
+                    {static_cast<std::uint64_t>(curr_cost) * 2 +
+                         static_cast<std::uint64_t>(P::upper_bound_heuristic(
+                             params, std::min(beeline_distance_, 1000.0))),
+                     static_cast<std::uint64_t>(
+                         curr_cost + P::upper_bound_heuristic(params, 10000U)),
+                     static_cast<std::uint64_t>(kInfeasible - 1U)})));
+            if (remaining_destinations_ == 0U) {
+              all_settled_key_ = l.cost();
+            }
+          }
+          if (all_settled_key_ == kInfeasible &&
+              curr_cost > early_termination_max_cost_) {
+            terminated_early_max_cost_ = true;
             break;
           }
-        }
-        if (curr_cost > early_termination_max_cost_) {
-          terminated_early_max_cost_ = true;
+        } else if (l.cost() > all_settled_key_) {
           break;
         }
       }
@@ -306,6 +317,7 @@ struct astar {
   std::vector<bool> settled_;
   std::size_t remaining_destinations_{0U};
   cost_t early_termination_max_cost_{kInfeasible};
+  cost_t all_settled_key_{kInfeasible};
   bool terminated_early_max_cost_{false};
   geo::latlng dest_centroid_{};
   double dest_radius_{};

--- a/include/osr/routing/bidirectional.h
+++ b/include/osr/routing/bidirectional.h
@@ -87,9 +87,9 @@ struct bidirectional {
     auto const heur =
         heuristic(params_.profile_, w, l.n_, dir, params_.sharing());
     if (l.cost() + heur < d.n_buckets() - 1U &&
-        cost_map[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                                node::invalid(), duration,
-                                                *w.r_, arena_)) {
+        cost_map[l.get_node().get_key()].update(
+            l, l.get_node(), {.cost_ = l.cost(), .duration_ = duration},
+            node::invalid(), *w.r_, arena_)) {
       auto const total = static_cast<cost_t>(l.cost() + heur);
       d.push(label{l.get_node(), total});
     }
@@ -209,8 +209,9 @@ struct bidirectional {
           }
           auto const total =
               clamp_cost(static_cast<std::uint64_t>(curr_cost) + cost);
-          auto const total_duration =
-              clamp_add_duration(curr_duration, duration);
+          auto const next_cd = cost_and_duration{
+              .cost_ = total,
+              .duration_ = clamp_add_duration(curr_duration, duration)};
           auto const heur =
               clamp_cost(static_cast<std::int64_t>(total) +
                          static_cast<std::int64_t>(heuristic(
@@ -229,9 +230,8 @@ struct bidirectional {
             }
             auto next = label{neighbor, static_cast<cost_t>(heur)};
             next.track(l, r, way, neighbor.get_node(), track);
-            if (!costs[neighbor.get_key()].update(
-                    next, neighbor, static_cast<cost_t>(total), curr,
-                    total_duration, r, arena_)) {
+            if (!costs[neighbor.get_key()].update(next, neighbor, next_cd, curr,
+                                                  r, arena_)) {
               return false;
             }
             pq.push(std::move(next));

--- a/include/osr/routing/dijkstra.h
+++ b/include/osr/routing/dijkstra.h
@@ -49,6 +49,7 @@ struct dijkstra {
       settled_.clear();
       remaining_destinations_ = 0U;
       early_termination_max_cost_ = kInfeasible;
+      all_settled_key_ = kInfeasible;
       terminated_early_max_cost_ = false;
     }
   }
@@ -127,23 +128,33 @@ struct dijkstra {
       }
 
       if constexpr (EarlyTermination) {
-        if (settle_destination(l.get_node())) {
-          auto const curr_cost = get_cost(l.get_node());
-          early_termination_max_cost_ = std::min(
-              early_termination_max_cost_,
-              static_cast<cost_t>(std::min(
-                  {static_cast<std::uint64_t>(curr_cost) * 2 +
-                       static_cast<std::uint64_t>(
-                           P::upper_bound_heuristic(params, 1500U)),
-                   static_cast<std::uint64_t>(
-                       curr_cost + P::upper_bound_heuristic(params, 10000U)),
-                   static_cast<std::uint64_t>(kInfeasible - 1U)})));
-          if (remaining_destinations_ == 0U) {
+        // Settling a destination fixes its cost, but not yet its duration:
+        // The queue can still contain equal-cost entries with shorter
+        // durations, and these could reach a destination using 0-cost edges.
+        // Therefore, we can only terminate once the current queue bucket is
+        // empty.
+        if (all_settled_key_ == kInfeasible) {
+          if (settle_destination(l.get_node())) {
+            auto const curr_cost = get_cost(l.get_node());
+            early_termination_max_cost_ = std::min(
+                early_termination_max_cost_,
+                static_cast<cost_t>(std::min(
+                    {static_cast<std::uint64_t>(curr_cost) * 2 +
+                         static_cast<std::uint64_t>(
+                             P::upper_bound_heuristic(params, 1500U)),
+                     static_cast<std::uint64_t>(
+                         curr_cost + P::upper_bound_heuristic(params, 10000U)),
+                     static_cast<std::uint64_t>(kInfeasible - 1U)})));
+            if (remaining_destinations_ == 0U) {
+              all_settled_key_ = l.cost();
+            }
+          }
+          if (all_settled_key_ == kInfeasible &&
+              l.cost() > early_termination_max_cost_) {
+            terminated_early_max_cost_ = true;
             break;
           }
-        }
-        if (l.cost() > early_termination_max_cost_) {
-          terminated_early_max_cost_ = true;
+        } else if (l.cost() > all_settled_key_) {
           break;
         }
       }
@@ -219,6 +230,7 @@ struct dijkstra {
   std::vector<bool> settled_;
   std::size_t remaining_destinations_{0U};
   cost_t early_termination_max_cost_{kInfeasible};
+  cost_t all_settled_key_{kInfeasible};
   bool terminated_early_max_cost_{false};
 };
 

--- a/include/osr/routing/dijkstra.h
+++ b/include/osr/routing/dijkstra.h
@@ -58,9 +58,9 @@ struct dijkstra {
 
   void add_start(label const l, duration_t const duration) {
     auto const& w = params_.w();
-    if (cost_[l.get_node().get_key()].update(l, l.get_node(), l.cost(),
-                                             node::invalid(), duration, *w.r_,
-                                             arena_)) {
+    if (cost_[l.get_node().get_key()].update(
+            l, l.get_node(), {.cost_ = l.cost(), .duration_ = duration},
+            node::invalid(), *w.r_, arena_)) {
       if constexpr (kDebug) {
         std::cout << "START ";
         l.get_node().print(std::cout, w);
@@ -184,13 +184,13 @@ struct dijkstra {
               max_reached_ = true;
               return;
             }
-            auto const total_duration =
-                clamp_add_duration(curr_duration, duration);
-            auto next = label{neighbor, static_cast<cost_t>(total)};
+            auto const next_cd = cost_and_duration{
+                .cost_ = static_cast<cost_t>(total),
+                .duration_ = clamp_add_duration(curr_duration, duration)};
+            auto next = label{neighbor, next_cd.cost_};
             next.track(l, r, way, neighbor.get_node(), track);
-            if (cost_[neighbor.get_key()].update(
-                    next, neighbor, static_cast<cost_t>(total), curr,
-                    total_duration, r, arena_)) {
+            if (cost_[neighbor.get_key()].update(next, neighbor, next_cd, curr,
+                                                 r, arena_)) {
               pq_.push(std::move(next));
 
               if constexpr (kDebug) {

--- a/include/osr/routing/dijkstra.h
+++ b/include/osr/routing/dijkstra.h
@@ -46,6 +46,7 @@ struct dijkstra {
     max_reached_ = false;
     if constexpr (EarlyTermination) {
       destinations_.clear();
+      settled_.clear();
       remaining_destinations_ = 0U;
       early_termination_max_cost_ = kInfeasible;
       terminated_early_max_cost_ = false;
@@ -75,10 +76,31 @@ struct dijkstra {
     if constexpr (EarlyTermination) {
       auto it = std::lower_bound(begin(destinations_), end(destinations_), n);
       if (it == end(destinations_) || *it != n) {
+        settled_.insert(
+            begin(settled_) + std::distance(begin(destinations_), it), false);
         destinations_.insert(it, n);
         ++remaining_destinations_;
       }
     }
+  }
+
+  bool settle_destination(node const n) {
+    auto const it =
+        std::lower_bound(begin(destinations_), end(destinations_), n);
+    if (it == end(destinations_) || *it != n) {
+      return false;
+    }
+    auto const idx =
+        static_cast<std::size_t>(std::distance(begin(destinations_), it));
+    if (settled_[idx]) {
+      // equal-cost labels with shorter durations can re-enter the queue, so the
+      // same destination can be popped more than once and must only be counted
+      // once
+      return false;
+    }
+    settled_[idx] = true;
+    --remaining_destinations_;
+    return true;
   }
 
   cost_t get_cost(node const n) const {
@@ -105,9 +127,7 @@ struct dijkstra {
       }
 
       if constexpr (EarlyTermination) {
-        if (std::find(begin(destinations_), end(destinations_), l.get_node()) !=
-            end(destinations_)) {
-          --remaining_destinations_;
+        if (settle_destination(l.get_node())) {
           auto const curr_cost = get_cost(l.get_node());
           early_termination_max_cost_ = std::min(
               early_termination_max_cost_,
@@ -196,6 +216,7 @@ struct dijkstra {
 
   // for early termination
   std::vector<node> destinations_;
+  std::vector<bool> settled_;
   std::size_t remaining_destinations_{0U};
   cost_t early_termination_max_cost_{kInfeasible};
   bool terminated_early_max_cost_{false};

--- a/include/osr/routing/path_reconstruction.h
+++ b/include/osr/routing/path_reconstruction.h
@@ -193,22 +193,4 @@ inline double add_path(typename P::parameters const& params,
   return distance;
 }
 
-template <Profile P>
-inline double add_path(typename P::parameters const& params,
-                       ways const& w,
-                       ways::routing const& r,
-                       bitvec<node_idx_t> const* blocked,
-                       sharing_data const* sharing,
-                       elevation_storage const* elevations,
-                       typename P::node const from,
-                       typename P::node const to,
-                       cost_t const expected_cost,
-                       std::vector<path::segment>& path,
-                       direction const dir) {
-  return add_path<P>(params, w, r, blocked, sharing, elevations, from, to,
-                     duration_from_cost(expected_cost), std::nullopt,
-                     expected_cost, duration_from_cost(expected_cost), path,
-                     dir);
-}
-
 }  // namespace osr

--- a/include/osr/routing/profile.h
+++ b/include/osr/routing/profile.h
@@ -66,14 +66,11 @@ concept IsEntry =
     } && requires(Entry entry,
                   Node const node,
                   Label const& label,
-                  cost_t const cost,
-                  duration_t const duration,
+                  cost_and_duration const cd,
                   ways::routing const& w,
                   entry_storage_arena& arena,
                   path& p) {
-      {
-        entry.update(label, node, cost, node, duration, w, arena)
-      } -> std::same_as<bool>;
+      { entry.update(label, node, cd, node, w, arena) } -> std::same_as<bool>;
     };
 
 template <typename Hash, typename NodeKey>

--- a/include/osr/routing/profiles/bike.h
+++ b/include/osr/routing/profiles/bike.h
@@ -114,21 +114,23 @@ struct bike {
     }
 
     constexpr duration_t duration(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return duration_[idx];
+      return duration_[get_index(n)];
+    }
+
+    constexpr cost_and_duration cd(std::size_t const idx) const noexcept {
+      return {.cost_ = cost_[idx], .duration_ = duration_[idx]};
     }
 
     constexpr bool update(label const&,
                           node const n,
-                          cost_t const c,
+                          cost_and_duration const c,
                           node const pred,
-                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
-      if (is_better_than(c, duration, cost_[idx], duration_[idx])) {
-        cost_[idx] = c;
-        duration_[idx] = duration;
+      if (c < cd(idx)) {
+        cost_[idx] = c.cost_;
+        duration_[idx] = c.duration_;
         pred_[idx] = pred.n_;
         pred_dir_[idx] = pred.dir_;
         return true;

--- a/include/osr/routing/profiles/bike.h
+++ b/include/osr/routing/profiles/bike.h
@@ -97,6 +97,7 @@ struct bike {
 
   struct entry {
     entry() {
+      utl::fill(duration_, kMaxDuration);
       utl::fill(cost_, kInfeasible);
       utl::fill(pred_, node_idx_t::invalid());
     }
@@ -113,19 +114,21 @@ struct bike {
     }
 
     constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+      auto const idx = get_index(n);
+      return duration_[idx];
     }
 
     constexpr bool update(label const&,
                           node const n,
                           cost_t const c,
                           node const pred,
-                          duration_t const,
+                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
-      if (c < cost_[idx]) {
+      if (is_better_than(c, duration, cost_[idx], duration_[idx])) {
         cost_[idx] = c;
+        duration_[idx] = duration;
         pred_[idx] = pred.n_;
         pred_dir_[idx] = pred.dir_;
         return true;
@@ -147,6 +150,7 @@ struct bike {
     std::array<node_idx_t, 2U> pred_;
     std::array<direction, 2U> pred_dir_;
     std::array<cost_t, 2U> cost_;
+    std::array<duration_t, 2U> duration_;
   };
 
   static node create_node(node_idx_t const n,

--- a/include/osr/routing/profiles/bike_sharing.h
+++ b/include/osr/routing/profiles/bike_sharing.h
@@ -206,6 +206,7 @@ struct bike_sharing {
         static_cast<std::underlying_type_t<node_type>>(node_type::kInvalid);
 
     entry() {
+      utl::fill(duration_, kMaxDuration);
       utl::fill(pred_, node_idx_t::invalid());
       utl::fill(cost_, kInfeasible);
       utl::fill(pred_lvl_, kNoLevel);
@@ -226,19 +227,21 @@ struct bike_sharing {
     }
 
     constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+      auto const idx = get_index(n);
+      return duration_[idx];
     }
 
     constexpr bool update(label const,
                           node const n,
                           cost_t const c,
                           node const pred,
-                          duration_t const,
+                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
-      if (c < cost_[idx]) {
+      if (is_better_than(c, duration, cost_[idx], duration_[idx])) {
         cost_[idx] = c;
+        duration_[idx] = duration;
         pred_[idx] = pred.n_;
         pred_lvl_[idx] = pred.lvl_;
         pred_type_[idx] = pred.type_;
@@ -257,6 +260,7 @@ struct bike_sharing {
     std::array<cost_t, kN> cost_{};
     std::array<level_t, kN> pred_lvl_{};
     std::array<node_type, kN> pred_type_{};
+    std::array<duration_t, kN> duration_;
   };
 
   static footp::node to_foot(node const n) {

--- a/include/osr/routing/profiles/bike_sharing.h
+++ b/include/osr/routing/profiles/bike_sharing.h
@@ -227,21 +227,23 @@ struct bike_sharing {
     }
 
     constexpr duration_t duration(node const n) const noexcept {
-      auto const idx = get_index(n);
-      return duration_[idx];
+      return duration_[get_index(n)];
+    }
+
+    constexpr cost_and_duration cd(std::size_t const idx) const noexcept {
+      return {.cost_ = cost_[idx], .duration_ = duration_[idx]};
     }
 
     constexpr bool update(label const,
                           node const n,
-                          cost_t const c,
+                          cost_and_duration const c,
                           node const pred,
-                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
       auto const idx = get_index(n);
-      if (is_better_than(c, duration, cost_[idx], duration_[idx])) {
-        cost_[idx] = c;
-        duration_[idx] = duration;
+      if (c < cd(idx)) {
+        cost_[idx] = c.cost_;
+        duration_[idx] = c.duration_;
         pred_[idx] = pred.n_;
         pred_lvl_[idx] = pred.lvl_;
         pred_type_[idx] = pred.type_;

--- a/include/osr/routing/profiles/car.h
+++ b/include/osr/routing/profiles/car.h
@@ -23,6 +23,10 @@ struct car_slot {
   way_pos_t pred_way_{0U};
   bool pred_dir_{false};
   duration_t duration_{kMaxDuration};
+
+  constexpr cost_and_duration cd() const noexcept {
+    return {.cost_ = cost_, .duration_ = duration_};
+  }
 };
 
 template <bool IsBus>
@@ -132,17 +136,16 @@ struct generic_car {
 
     bool update(label const&,
                 node const n,
-                cost_t const c,
+                cost_and_duration const c,
                 node const pred,
-                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
+      if (c >= s.cd()) {
         return false;
       }
-      s.cost_ = c;
-      s.duration_ = duration;
+      s.cost_ = c.cost_;
+      s.duration_ = c.duration_;
       s.pred_ = pred.n_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);

--- a/include/osr/routing/profiles/car.h
+++ b/include/osr/routing/profiles/car.h
@@ -22,6 +22,7 @@ struct car_slot {
   cost_t cost_{kInfeasible};
   way_pos_t pred_way_{0U};
   bool pred_dir_{false};
+  duration_t duration_{kMaxDuration};
 };
 
 template <bool IsBus>
@@ -125,22 +126,23 @@ struct generic_car {
 
     cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+    duration_t duration(node const n) const noexcept {
+      return s_[get_index(n)].duration_;
     }
 
     bool update(label const&,
                 node const n,
                 cost_t const c,
                 node const pred,
-                duration_t const,
+                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (c >= s.cost_) {
+      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
         return false;
       }
       s.cost_ = c;
+      s.duration_ = duration;
       s.pred_ = pred.n_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);
@@ -338,11 +340,13 @@ struct generic_car {
   static constexpr cost_and_duration node_cost(parameters const& params,
                                                node_properties const& n) {
     if constexpr (IsBus) {
-      return n.is_bus_accessible() ? cost_and_duration_from_cost(0U)
-                                   : (n.is_bus_accessible_with_penalty()
-                                          ? cost_and_duration_from_cost(
-                                                params.private_gate_penalty_)
-                                          : infeasible_cost_and_duration());
+      return n.is_bus_accessible()
+                 ? cost_and_duration_from_cost(0U)
+                 : (n.is_bus_accessible_with_penalty()
+                        ? cost_and_duration{.cost_ =
+                                                params.private_gate_penalty_,
+                                            .duration_ = duration_t{0}}
+                        : infeasible_cost_and_duration());
     } else {
       return n.is_car_accessible() ? cost_and_duration_from_cost(0U)
                                    : infeasible_cost_and_duration();

--- a/include/osr/routing/profiles/car_parking.h
+++ b/include/osr/routing/profiles/car_parking.h
@@ -25,6 +25,10 @@ struct car_parking_slot {
   std::uint8_t pred_dir_ : 1 {0U};
   std::uint8_t pred_type_ : 1 {0U};
   duration_t duration_{kMaxDuration};
+
+  constexpr cost_and_duration cd() const noexcept {
+    return {.cost_ = cost_, .duration_ = duration_};
+  }
 };
 
 template <bool IsWheelchair, bool UseParking = true>
@@ -169,17 +173,16 @@ struct car_parking {
 
     bool update(label const,
                 node const n,
-                cost_t const c,
+                cost_and_duration const c,
                 node const pred,
-                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
+      if (c >= s.cd()) {
         return false;
       }
-      s.cost_ = c;
-      s.duration_ = duration;
+      s.cost_ = c.cost_;
+      s.duration_ = c.duration_;
       s.pred_ = pred.n_;
       s.pred_lvl_ = pred.lvl_;
       s.pred_type_ = to_bool(pred.type_);

--- a/include/osr/routing/profiles/car_parking.h
+++ b/include/osr/routing/profiles/car_parking.h
@@ -11,19 +11,21 @@
 #include "osr/routing/profiles/car.h"
 #include "osr/routing/profiles/foot.h"
 #include "osr/ways.h"
+#include "utl/helpers/algorithm.h"
 
 namespace osr {
+
+struct sharing_data;
 
 struct car_parking_slot {
   node_idx_t pred_{node_idx_t::invalid()};
   cost_t cost_{kInfeasible};
   level_t pred_lvl_{kNoLevel};
-  way_pos_t pred_way_{0U};
-  bool pred_dir_{false};
-  bool pred_type_{false};
+  std::uint8_t pred_way_ : 5 {0U};
+  std::uint8_t pred_dir_ : 1 {0U};
+  std::uint8_t pred_type_ : 1 {0U};
+  duration_t duration_{kMaxDuration};
 };
-
-struct sharing_data;
 
 template <bool IsWheelchair, bool UseParking = true>
 struct car_parking {
@@ -161,22 +163,23 @@ struct car_parking {
 
     cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+    duration_t duration(node const n) const noexcept {
+      return s_[get_index(n)].duration_;
     }
 
     bool update(label const,
                 node const n,
                 cost_t const c,
                 node const pred,
-                duration_t const,
+                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (c >= s.cost_) {
+      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
         return false;
       }
       s.cost_ = c;
+      s.duration_ = duration;
       s.pred_ = pred.n_;
       s.pred_lvl_ = pred.lvl_;
       s.pred_type_ = to_bool(pred.type_);

--- a/include/osr/routing/profiles/car_sharing.h
+++ b/include/osr/routing/profiles/car_sharing.h
@@ -222,20 +222,18 @@ struct car_sharing {
     level_t lvl_;
     direction dir_;
     way_pos_t way_;
-#ifdef _MSC_VER
-    [[no_unique_address]] [[msvc::no_unique_address]] Tracking tracking_{};
-#else
-    [[no_unique_address]] Tracking tracking_{};
-#endif
+    OSR_NO_UNIQUE_ADDRESS Tracking tracking_{};
   };
 
   struct slot {
     node_idx_t pred_{node_idx_t::invalid()};
     cost_t cost_{kInfeasible};
     level_t pred_lvl_{kNoLevel};
-    node_type pred_type_{node_type::kInvalid};
-    way_pos_t pred_way_{0U};
-    bool pred_dir_{false};
+    std::uint8_t pred_way_ : 5 {0U};
+    std::uint8_t pred_dir_ : 1 {0U};
+    std::uint8_t pred_type_
+        : 2 {static_cast<std::uint8_t>(node_type::kInvalid)};
+    duration_t duration_{kMaxDuration};
     OSR_NO_UNIQUE_ADDRESS Tracking tracking_{};
   };
 
@@ -250,36 +248,38 @@ struct car_sharing {
       auto const s = s_[get_index(n)];
       return s.pred_ == node_idx_t::invalid()
                  ? std::nullopt
-                 : std::optional{node{.n_ = s.pred_,
-                                      .type_ = s.pred_type_,
-                                      .lvl_ = s.pred_lvl_,
-                                      .dir_ = to_dir(s.pred_dir_),
-                                      .way_ = s.pred_way_}};
+                 : std::optional{
+                       node{.n_ = s.pred_,
+                            .type_ = static_cast<node_type>(s.pred_type_),
+                            .lvl_ = s.pred_lvl_,
+                            .dir_ = to_dir(s.pred_dir_),
+                            .way_ = s.pred_way_}};
     }
 
     cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+    duration_t duration(node const n) const noexcept {
+      return s_[get_index(n)].duration_;
     }
 
     bool update(label const& l,
                 node const n,
                 cost_t const c,
                 node const pred,
-                duration_t const,
+                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (c >= s.cost_) {
+      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
         return false;
       }
       s.cost_ = c;
+      s.duration_ = duration;
       s.pred_ = pred.n_;
       s.pred_lvl_ = pred.lvl_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);
-      s.pred_type_ = pred.type_;
+      s.pred_type_ = static_cast<std::uint8_t>(pred.type_);
       s.tracking_ = l.tracking_;
       return true;
     }

--- a/include/osr/routing/profiles/car_sharing.h
+++ b/include/osr/routing/profiles/car_sharing.h
@@ -235,6 +235,10 @@ struct car_sharing {
         : 2 {static_cast<std::uint8_t>(node_type::kInvalid)};
     duration_t duration_{kMaxDuration};
     OSR_NO_UNIQUE_ADDRESS Tracking tracking_{};
+
+    constexpr cost_and_duration cd() const noexcept {
+      return {.cost_ = cost_, .duration_ = duration_};
+    }
   };
 
   struct entry {
@@ -264,17 +268,16 @@ struct car_sharing {
 
     bool update(label const& l,
                 node const n,
-                cost_t const c,
+                cost_and_duration const c,
                 node const pred,
-                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
+      if (c >= s.cd()) {
         return false;
       }
-      s.cost_ = c;
-      s.duration_ = duration;
+      s.cost_ = c.cost_;
+      s.duration_ = c.duration_;
       s.pred_ = pred.n_;
       s.pred_lvl_ = pred.lvl_;
       s.pred_way_ = pred.way_;

--- a/include/osr/routing/profiles/common.h
+++ b/include/osr/routing/profiles/common.h
@@ -168,10 +168,10 @@ std::tuple<typename P::node, cost_t, duration_t> get_adjacent_additional_node(
 
   auto const target = typename P::node{
       ae.to_, additional->get_way_pos(w, ae.to_, ae.underlying_way_), edge_dir};
-  auto total = clamp_add(edge_cost, turn_cost);
+  auto total = clamp_add(edge_cost, turn_cost, duration_t{0});
 
   if (is_u_turn) {
-    total = clamp_add(total, uturn_penalty);
+    total = clamp_add(total, uturn_penalty, duration_t{0});
   }
 
   if (!additional->is_additional_node(ae.to_)) {
@@ -266,9 +266,9 @@ void for_each_adjacent_node(typename P::parameters const& params,
         return;
       }
 
-      auto total = clamp_add(clamp_add(wc, nc), turn_cost);
+      auto total = clamp_add(clamp_add(wc, nc), turn_cost, duration_t{0});
       if (is_u_turn) {
-        total = clamp_add(total, uturn_penalty);
+        total = clamp_add(total, uturn_penalty, duration_t{0});
       }
       fn(target, total.cost_, total.duration_, dist, way, from, to,
          elevation_storage::elevation{}, false);

--- a/include/osr/routing/profiles/ferry.h
+++ b/include/osr/routing/profiles/ferry.h
@@ -87,16 +87,19 @@ struct ferry {
 
     constexpr duration_t duration(node) const noexcept { return duration_; }
 
+    constexpr cost_and_duration cd() const noexcept {
+      return {.cost_ = cost_, .duration_ = duration_};
+    }
+
     constexpr bool update(label const&,
                           node const,
-                          cost_t const c,
+                          cost_and_duration const c,
                           node const pred,
-                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
-      if (is_better_than(c, duration, cost_, duration_)) {
-        cost_ = c;
-        duration_ = duration;
+      if (c < cd()) {
+        cost_ = c.cost_;
+        duration_ = c.duration_;
         pred_ = pred.n_;
         return true;
       }

--- a/include/osr/routing/profiles/ferry.h
+++ b/include/osr/routing/profiles/ferry.h
@@ -85,19 +85,18 @@ struct ferry {
 
     constexpr cost_t cost(node const) const noexcept { return cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
-    }
+    constexpr duration_t duration(node) const noexcept { return duration_; }
 
     constexpr bool update(label const&,
                           node const,
                           cost_t const c,
                           node const pred,
-                          duration_t const,
+                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
-      if (c < cost_) {
+      if (is_better_than(c, duration, cost_, duration_)) {
         cost_ = c;
+        duration_ = duration;
         pred_ = pred.n_;
         return true;
       }
@@ -108,6 +107,7 @@ struct ferry {
 
     node_idx_t pred_{node_idx_t::invalid()};
     cost_t cost_{kInfeasible};
+    duration_t duration_{kMaxDuration};
   };
 
   struct hash {

--- a/include/osr/routing/profiles/foot.h
+++ b/include/osr/routing/profiles/foot.h
@@ -92,17 +92,20 @@ struct foot {
 
     constexpr duration_t duration(node) const noexcept { return duration_; }
 
+    constexpr cost_and_duration cd() const noexcept {
+      return {.cost_ = cost_, .duration_ = duration_};
+    }
+
     constexpr bool update(label const& l,
                           node,
-                          cost_t const c,
+                          cost_and_duration const c,
                           node const pred,
-                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
-      if (is_better_than(c, duration, cost_, duration_)) {
+      if (c < cd()) {
         tracking_ = l.tracking_;
-        cost_ = c;
-        duration_ = duration;
+        cost_ = c.cost_;
+        duration_ = c.duration_;
         pred_ = pred.n_;
         pred_lvl_ = pred.lvl_;
         return true;

--- a/include/osr/routing/profiles/foot.h
+++ b/include/osr/routing/profiles/foot.h
@@ -90,20 +90,19 @@ struct foot {
     }
     constexpr cost_t cost(node) const noexcept { return cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
-    }
+    constexpr duration_t duration(node) const noexcept { return duration_; }
 
     constexpr bool update(label const& l,
                           node,
                           cost_t const c,
                           node const pred,
-                          duration_t const,
+                          duration_t const duration,
                           ways::routing const&,
                           entry_storage_arena&) noexcept {
-      if (c < cost_) {
+      if (is_better_than(c, duration, cost_, duration_)) {
         tracking_ = l.tracking_;
         cost_ = c;
+        duration_ = duration;
         pred_ = pred.n_;
         pred_lvl_ = pred.lvl_;
         return true;
@@ -115,6 +114,7 @@ struct foot {
 
     node_idx_t pred_{node_idx_t::invalid()};
     cost_t cost_{kInfeasible};
+    duration_t duration_{kMaxDuration};
     level_t pred_lvl_;
     OSR_NO_UNIQUE_ADDRESS Tracking tracking_;
   };

--- a/include/osr/routing/profiles/hgv.h
+++ b/include/osr/routing/profiles/hgv.h
@@ -168,7 +168,7 @@ struct hgv {
                 entry_storage_arena& a) {
       n_ = n.n_;
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!(c < s.cost_ || (c == s.cost_ && duration < s.duration_))) {
+      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
         return false;
       }
       s.cost_ = c;

--- a/include/osr/routing/profiles/hgv.h
+++ b/include/osr/routing/profiles/hgv.h
@@ -33,6 +33,10 @@ struct hgv_slot {
   way_pos_t pred_way_{0U};
   bool pred_dir_{false};
   duration_t duration_{kMaxDuration};
+
+  constexpr cost_and_duration cd() const noexcept {
+    return {.cost_ = cost_, .duration_ = duration_};
+  }
 };
 
 struct hgv {
@@ -150,29 +154,19 @@ struct hgv {
       return s_[get_index(n)].duration_;
     }
 
-    bool update(label const& l,
-                node const n,
-                cost_t const c,
-                node const pred,
-                ways::routing const& w,
-                entry_storage_arena& a) {
-      return update(l, n, c, pred, duration_from_cost(c), w, a);
-    }
-
     bool update(label const&,
                 node const n,
-                cost_t const c,
+                cost_and_duration const c,
                 node const pred,
-                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       n_ = n.n_;
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
+      if (c >= s.cd()) {
         return false;
       }
-      s.cost_ = c;
-      s.duration_ = duration;
+      s.cost_ = c.cost_;
+      s.duration_ = c.duration_;
       s.pred_ = pred.n_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);

--- a/include/osr/routing/profiles/railway.h
+++ b/include/osr/routing/profiles/railway.h
@@ -22,6 +22,7 @@ struct railway_slot {
   cost_t cost_{kInfeasible};
   way_pos_t pred_way_{0U};
   bool pred_dir_{false};
+  duration_t duration_{kMaxDuration};
 };
 
 struct railway {
@@ -125,22 +126,23 @@ struct railway {
 
     cost_t cost(node const n) const noexcept { return s_[get_index(n)].cost_; }
 
-    constexpr duration_t duration(node const n) const noexcept {
-      return duration_from_cost(cost(n));
+    duration_t duration(node const n) const noexcept {
+      return s_[get_index(n)].duration_;
     }
 
     bool update(label const&,
                 node const n,
                 cost_t const c,
                 node const pred,
-                duration_t const,
+                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (c >= s.cost_) {
+      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
         return false;
       }
       s.cost_ = c;
+      s.duration_ = duration;
       s.pred_ = pred.n_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);

--- a/include/osr/routing/profiles/railway.h
+++ b/include/osr/routing/profiles/railway.h
@@ -23,6 +23,10 @@ struct railway_slot {
   way_pos_t pred_way_{0U};
   bool pred_dir_{false};
   duration_t duration_{kMaxDuration};
+
+  constexpr cost_and_duration cd() const noexcept {
+    return {.cost_ = cost_, .duration_ = duration_};
+  }
 };
 
 struct railway {
@@ -132,17 +136,16 @@ struct railway {
 
     bool update(label const&,
                 node const n,
-                cost_t const c,
+                cost_and_duration const c,
                 node const pred,
-                duration_t const duration,
                 ways::routing const& w,
                 entry_storage_arena& a) {
       auto& s = s_.slot(get_index(n), w, n.n_, a);
-      if (!is_better_than(c, duration, s.cost_, s.duration_)) {
+      if (c >= s.cd()) {
         return false;
       }
-      s.cost_ = c;
-      s.duration_ = duration;
+      s.cost_ = c.cost_;
+      s.duration_ = c.duration_;
       s.pred_ = pred.n_;
       s.pred_way_ = pred.way_;
       s.pred_dir_ = to_bool(pred.dir_);

--- a/include/osr/types.h
+++ b/include/osr/types.h
@@ -209,16 +209,11 @@ constexpr duration_t duration_from_cost(T const c) {
   return clamp_duration(static_cast<std::uint64_t>(c));
 }
 
-constexpr bool is_better_than(cost_t const cost,
-                              duration_t const duration,
-                              cost_t const other_cost,
-                              duration_t const other_duration) noexcept {
-  return cost < other_cost || (cost == other_cost && duration < other_duration);
-}
-
 struct cost_and_duration {
   cost_t cost_{0U};
   duration_t duration_{0U};
+
+  constexpr auto operator<=>(cost_and_duration const&) const noexcept = default;
 
   constexpr bool feasible() const noexcept { return cost_ != kInfeasible; }
 };

--- a/include/osr/types.h
+++ b/include/osr/types.h
@@ -209,6 +209,13 @@ constexpr duration_t duration_from_cost(T const c) {
   return clamp_duration(static_cast<std::uint64_t>(c));
 }
 
+constexpr bool is_better_than(cost_t const cost,
+                              duration_t const duration,
+                              cost_t const other_cost,
+                              duration_t const other_duration) noexcept {
+  return cost < other_cost || (cost == other_cost && duration < other_duration);
+}
+
 struct cost_and_duration {
   cost_t cost_{0U};
   duration_t duration_{0U};

--- a/src/map_matching.cc
+++ b/src/map_matching.cc
@@ -521,6 +521,7 @@ matched_route map_match(
   }
 
   result.path_.cost_ = 0;
+  result.path_.duration_ = duration_t{0U};
   /*
    Reconstruction starts with the last segment and goes backwards.
    For each segment the destination may be known (from reconstruction of the
@@ -592,6 +593,7 @@ matched_route map_match(
       result.path_.segments_.emplace_back(path::segment{
           .polyline_ = {from_pos, to_pos},
           .cost_ = cost,
+          .duration_ = duration_from_cost(cost),
           .dist_ = dist,
       });
       seg.path_segments_ += 1U;
@@ -674,8 +676,13 @@ matched_route map_match(
         auto const cost = entry.cost(*n);
 
         if (pred) {
+          auto const duration = entry.duration(*n);
+          auto const pred_duration =
+              d.cost_.at(pred->get_key()).duration(*pred);
           auto const expected_cost =
               static_cast<cost_t>(cost - d.get_cost(*pred));
+          auto const expected_duration =
+              clamp_sub_duration(duration, pred_duration);
 
           auto const pred_node_idx = pred->get_node();
           auto const curr_node_idx = n->get_node();
@@ -714,11 +721,13 @@ matched_route map_match(
                     curr_is_additional ? node_idx_t::invalid() : curr_node_idx,
                 .way_ = edge_way,
                 .cost_ = expected_cost,
+                .duration_ = expected_duration,
                 .dist_ = edge_dist,
                 .mode_ = n->get_mode()});
           } else {
             add_path<P>(params, w, *w.r_, blocked, seg.sharing_.get(),
-                        elevations, *pred, *n, expected_cost,
+                        elevations, *pred, *n, pred_duration, std::nullopt,
+                        expected_cost, expected_duration,
                         result.path_.segments_, direction::kForward);
           }
         } else {
@@ -755,6 +764,8 @@ matched_route map_match(
     result.path_.cost_ =
         clamp_cost(static_cast<std::uint64_t>(result.path_.cost_) +
                    static_cast<std::uint64_t>(seg.cost_));
+    result.path_.duration_ =
+        clamp_add_duration(result.path_.duration_, seg.duration_);
   }
 
   auto offset = std::size_t{0U};

--- a/src/route.cc
+++ b/src/route.cc
@@ -322,8 +322,7 @@ best_candidate(typename P::parameters const& params,
                bool should_continue,
                way_idx_t const start_way,
                double const limit_squared_max_matching_distance) {
-  auto best_cost = path{.cost_ = std::numeric_limits<cost_t>::max(),
-                        .duration_ = kMaxDuration};
+  auto best_cd = infeasible_cost_and_duration();
   auto best_node = P::node::invalid();
   auto best = candidate_node{};
   auto have_best = false;
@@ -331,7 +330,7 @@ best_candidate(typename P::parameters const& params,
   auto const get_best = [&](way_idx_t const dest_way, candidate_node const& x) {
     P::resolve_all(*w.r_, x.node_, lvl, [&](auto&& node) {
       auto const target_cost = search.get_cost(node);
-      if (target_cost == kInfeasible || target_cost > best_cost.cost_) {
+      if (target_cost == kInfeasible || target_cost > best_cd.cost_) {
         return;
       }
 
@@ -352,17 +351,15 @@ best_candidate(typename P::parameters const& params,
         return;
       }
 
-      auto const total_cost = target_cost + dest_way_cost.cost_;
-      auto const total_duration =
-          clamp_add_duration(target_duration, dest_way_cost.duration_);
-      if (total_cost < best_cost.cost_ ||
-          (total_cost == best_cost.cost_ &&
-           total_duration < best_cost.duration_)) {
+      auto const total = cost_and_duration{
+          .cost_ = static_cast<cost_t>(target_cost + dest_way_cost.cost_),
+          .duration_ =
+              clamp_add_duration(target_duration, dest_way_cost.duration_)};
+      if (total < best_cd) {
         best_node = node;
         best = x;
         have_best = true;
-        best_cost.cost_ = static_cast<cost_t>(total_cost);
-        best_cost.duration_ = total_duration;
+        best_cd = total;
       }
     });
   };
@@ -390,9 +387,11 @@ best_candidate(typename P::parameters const& params,
     }
 
     if (have_best) {
-      return best_cost.cost_ < max ? std::optional{std::tuple{
-                                         best, dest_way, best_node, best_cost}}
-                                   : std::nullopt;
+      return best_cd.cost_ < max ? std::optional{std::tuple{
+                                       best, dest_way, best_node,
+                                       path{.cost_ = best_cd.cost_,
+                                            .duration_ = best_cd.duration_}}}
+                                 : std::nullopt;
     }
   }
   return std::nullopt;

--- a/test/duration_tie_break_test.cc
+++ b/test/duration_tie_break_test.cc
@@ -1,0 +1,232 @@
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <memory>
+
+#include "cista/mmap.h"
+
+#include "osr/extract/extract.h"
+#include "osr/location.h"
+#include "osr/routing/astar.h"
+#include "osr/routing/dijkstra.h"
+#include "osr/routing/profiles/car.h"
+#include "osr/routing/search_params.h"
+#include "osr/types.h"
+#include "osr/ways.h"
+
+#include "xml_to_pbf.h"
+
+namespace fs = std::filesystem;
+using namespace osr;
+
+namespace {
+
+// Two routes reach node 6 at the same cost but with very different durations,
+// and both arrive there in the same routing state, so they compete for one
+// entry slot:
+//
+//   1 --way 1 (2x 236m @ 10km/h)--> 2 --> 3 --way 3 (7m @ 120km/h)--> 5
+//   1 --way 2 (28m @ 10km/h, motor_vehicle=destination)--> 4 --way 4 (7m)--> 5
+//   5 --way 5 (7m @ 120km/h)--> 6
+//
+// The car profile charges `5 * base + 120` on a `motor_vehicle=destination`
+// way but keeps the plain travel time as the duration, which is what makes the
+// two routes cost-equal and duration-different:
+//
+//   via node 3: cost 85 + 85 = 170, duration 170
+//   via node 4: cost 5 * 10 + 120 = 170, duration 10
+//
+// Ways 3, 4 and 5 are short enough at 120km/h that `rint(dist * s_per_m)`
+// rounds to 0, so they are edges with cost 0. That is what puts nodes 3 and 4
+// in the *same* cost bucket as nodes 5 and 6: the state at node 6 can still be
+// improved from inside the bucket it is settled in.
+//
+// Node 2 carries a stub way (way 6) so that it stays a junction and node 3 is
+// therefore pushed while bucket 85 is processed - after node 4, which is
+// pushed from bucket 0. `dial` pops a bucket LIFO, so the slow route is
+// expanded first and a search that stops at the first pop of node 6 settles
+// the 170s duration and never looks at node 4.
+constexpr auto const kOsm = R"(
+<osm version="0.6">
+  <node id="1" lat="49.0000000" lon="8.0000000"/>
+  <node id="2" lat="49.0021208" lon="8.0001000"/>
+  <node id="3" lat="49.0000000" lon="8.0002000"/>
+  <node id="4" lat="49.0000000" lon="8.0003833"/>
+  <node id="5" lat="49.0000000" lon="8.0002900"/>
+  <node id="6" lat="49.0000600" lon="8.0002900"/>
+  <node id="7" lat="49.0021208" lon="8.0004000"/>
+  <way id="1">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="10"/>
+  </way>
+  <way id="2">
+    <nd ref="1"/>
+    <nd ref="4"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="10"/>
+    <tag k="motor_vehicle" v="destination"/>
+  </way>
+  <way id="3">
+    <nd ref="3"/>
+    <nd ref="5"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="120"/>
+  </way>
+  <way id="4">
+    <nd ref="4"/>
+    <nd ref="5"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="120"/>
+  </way>
+  <way id="5">
+    <nd ref="5"/>
+    <nd ref="6"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="120"/>
+  </way>
+  <way id="6">
+    <nd ref="2"/>
+    <nd ref="7"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="10"/>
+  </way>
+  <way id="7">
+    <nd ref="6"/>
+    <nd ref="7"/>
+    <tag k="highway" v="residential"/>
+    <tag k="maxspeed" v="10"/>
+  </way>
+</osm>
+)";
+
+constexpr auto const kMaxCost = cost_t{10'000U};
+
+struct fixture {
+  fixture() {
+    dir_ = fs::temp_directory_path() / "osr_duration_tie_break_test";
+    auto ec = std::error_code{};
+    fs::remove_all(dir_, ec);
+    fs::create_directories(dir_, ec);
+    osr::extract(false,
+                 osr::test::write_osm_pbf("osr_duration_tie_break", kOsm), dir_,
+                 {});
+    w_ = std::make_unique<ways>(dir_, cista::mmap::protection::READ);
+
+    start_ = *w_->find_node_idx(osm_node_idx_t{1U});
+    auto const end_node = *w_->find_node_idx(osm_node_idx_t{6U});
+    // the state both routes arrive in: node 6, along way 5, forwards
+    end_ = car::node{
+        .n_ = end_node,
+        .way_ = w_->r_->get_way_pos(end_node, *w_->find_way(osm_way_idx_t{5U})),
+        .dir_ = direction::kForward};
+  }
+
+  template <typename Search>
+  cost_and_duration result(Search const& search) const {
+    auto const it = search.cost_.find(end_.get_key());
+    return it == end(search.cost_)
+               ? infeasible_cost_and_duration()
+               : cost_and_duration{.cost_ = it->second.cost(end_),
+                                   .duration_ = it->second.duration(end_)};
+  }
+
+  template <typename Fn>
+  void for_each_start_state(Fn&& f) const {
+    auto const ways = w_->r_->node_ways_[start_];
+    for (auto i = way_pos_t{0U}; i != ways.size(); ++i) {
+      f(car::node{.n_ = start_, .way_ = i, .dir_ = direction::kForward});
+      f(car::node{.n_ = start_, .way_ = i, .dir_ = direction::kBackward});
+    }
+  }
+
+  search_params<car::parameters> make_search_params() const {
+    return {.profile_ = params_,
+            .w_ = w_.get(),
+            .max_ = kMaxCost,
+            .dir_ = direction::kForward,
+            .start_loc_ = location{w_->get_node_pos(start_), kNoLevel},
+            .end_loc_ = location{w_->get_node_pos(end_.get_node()), kNoLevel}};
+  }
+
+  template <bool EarlyTermination>
+  cost_and_duration run_dijkstra(dijkstra<car, EarlyTermination>& d) const {
+    d.reset(make_search_params());
+    if constexpr (EarlyTermination) {
+      d.add_destination(end_);
+    }
+    for_each_start_state([&](car::node const n) {
+      d.add_start(car::label{n, 0U}, duration_t{0});
+    });
+    d.run();
+    return result(d);
+  }
+
+  template <bool EarlyTermination>
+  cost_and_duration run_astar(astar<car, EarlyTermination>& a) const {
+    a.reset(make_search_params());
+    a.add_destination(end_);
+    for_each_start_state([&](car::node const n) {
+      a.add_start(car::label{n, 0U}, duration_t{0});
+    });
+    a.run();
+    return result(a);
+  }
+
+  fs::path dir_;
+  std::unique_ptr<ways> w_;
+  car::parameters params_{};
+  node_idx_t start_{node_idx_t::invalid()};
+  car::node end_{car::node::invalid()};
+};
+
+}  // namespace
+
+// The fixture is only a regression test for the tie break as long as it really
+// does offer two cost-equal routes with different durations.
+// A change to the cost model should cause a failure here, so that the
+// tests can be updated to reflect the new cost model.
+TEST(duration_tie_break, fixture_has_a_cost_tie_with_distinct_durations) {
+  auto const f = fixture{};
+  auto d = dijkstra<car, false>{};
+  auto const r = f.run_dijkstra(d);
+
+  EXPECT_EQ(cost_t{170U}, r.cost_);
+  EXPECT_EQ(10, r.duration_.count());
+}
+
+TEST(duration_tie_break, early_termination_dijkstra_drains_the_bucket) {
+  auto const f = fixture{};
+
+  auto exhaustive = dijkstra<car, false>{};
+  auto const expected = f.run_dijkstra(exhaustive);
+  ASSERT_NE(kInfeasible, expected.cost_);
+
+  auto early = dijkstra<car, true>{};
+  auto const actual = f.run_dijkstra(early);
+
+  EXPECT_EQ(expected.cost_, actual.cost_);
+  EXPECT_EQ(expected.duration_.count(), actual.duration_.count())
+      << "early termination settled cost " << actual.cost_ << " with duration "
+      << actual.duration_.count() << ", but an equal cost route with duration "
+      << expected.duration_.count() << " was still pending in the bucket";
+}
+
+TEST(duration_tie_break, early_termination_astar_drains_the_bucket) {
+  auto const f = fixture{};
+
+  auto exhaustive = dijkstra<car, false>{};
+  auto const expected = f.run_dijkstra(exhaustive);
+  ASSERT_NE(kInfeasible, expected.cost_);
+
+  auto early = astar<car, true>{};
+  auto const actual = f.run_astar(early);
+
+  EXPECT_EQ(expected.cost_, actual.cost_);
+  EXPECT_EQ(expected.duration_.count(), actual.duration_.count())
+      << "early termination settled cost " << actual.cost_ << " with duration "
+      << actual.duration_.count() << ", but an equal cost route with duration "
+      << expected.duration_.count() << " was still pending in the bucket";
+}

--- a/test/map_matching_test.cc
+++ b/test/map_matching_test.cc
@@ -523,6 +523,17 @@ TEST_F(map_matching_london, northern_line) {
           osr::location{.pos_ = {51.427805, -0.168136}, .lvl_ = osr::kNoLevel},
       });
 
+  auto total_duration = osr::duration_t{0U};
+  auto has_preference_penalty = false;
+  for (auto const& segment : mr.path_.segments_) {
+    EXPECT_GT(segment.duration_, osr::duration_t{0U});
+    total_duration = osr::clamp_add_duration(total_duration, segment.duration_);
+    has_preference_penalty |=
+        segment.cost_ > static_cast<osr::cost_t>(segment.duration_.count());
+  }
+  EXPECT_EQ(total_duration, mr.path_.duration_);
+  EXPECT_TRUE(has_preference_penalty);
+
   EXPECT_EQ(
       R"({"type":"FeatureCollection","metadata":{},"features":[{"type":"Feature","properties":{"level":0E0,"osm_way_id":689129018,"cost":980,"distance":980},"geometry":{"type":"LineString","coordinates":[[-1.5277022640749896E-1,5.14434248276116E1],[-1.528186E-1,5.14433718E1],[-1.5296E-1,5.1443199E1],[-1.531195E-1,5.14430038E1],[-1.533013E-1,5.14427826E1],[-1.55187E-1,5.14404878E1],[-1.559461E-1,5.143928E1],[-1.566684E-1,5.14378739E1],[-1.572287E-1,5.14372959E1],[-1.583335E-1,5.14363843E1],[-1.589128E-1,5.14360081E1],[-1.590407E-1,5.14359333E1],[-1.592987E-1,5.14357824E1],[-1.5938785722441887E-1,5.143573876914223E1]]}},{"type":"Feature","properties":{"level":0E0,"osm_way_id":689129018,"cost":42,"distance":42},"geometry":{"type":"LineString","coordinates":[[-1.5938785722441887E-1,5.143573876914223E1],[-1.598208E-1,5.14355269E1]]}},{"type":"Feature","properties":{"level":0E0,"osm_way_id":689129018,"cost":1055,"distance":1052},"geometry":{"type":"LineString","coordinates":[[-1.598208E-1,5.14355269E1],[-1.604979E-1,5.14352418E1],[-1.612097E-1,5.14348656E1],[-1.615151E-1,5.14346777E1],[-1.621663E-1,5.14342415E1],[-1.627351E-1,5.14337909E1],[-1.634107E-1,5.14331139E1],[-1.635821E-1,5.14328656E1],[-1.637225E-1,5.14325488E1],[-1.639167E-1,5.14320762E1],[-1.640189E-1,5.14318777E1],[-1.647738E-1,5.14310947E1],[-1.666569E-1,5.14292455E1],[-1.67733E-1,5.1428231E1],[-1.67951E-1,5.14279696E1],[-1.681201E-1,5.14278007E1],[-1.6812182130106906E-1,5.142779909364883E1]]}}]})",
       osr::to_featurecollection(w_, mr.path_, false));


### PR DESCRIPTION
This PR adds duration tracking to all profiles (previously only the HGV profile had it).

Due to the SSO memory layout changes (#135), this is effectively free for the car, car\_parking, car\_sharing, railway and foot profiles (same memory usage as before).

For the remaining profiles it uses slightly more memory per entry:
- bike: 24 -> 28 bytes
- bike\_sharing: 40 -> 44 bytes
- ferry: 12 -> 16 bytes

Note that the duration is currently not used as an optimization criterion, only as a tie-breaker (shorter duration route is preferred if costs are equal).

In general, even though the MOTIS API accepts a "max duration", this was always a "max cost". With this PR it still is treated as a max cost limit. However, because the duration assigned to a route can now be different than the costs, this is now more confusing, because even if there is a route with duration=X, a max cost limit of X may not find it if the costs are >X.

Update: In #141, the API now takes a max duration parameter instead of max cost.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>