### PR TITLE
Bike: ignore node access at unbarriered crossings

### DIFF
--- a/include/osr/extract/tags.h
+++ b/include/osr/extract/tags.h
@@ -501,7 +501,12 @@ struct foot_profile {
 };
 
 struct bike_profile {
-  static override access_override(tags const& t, osm_obj_type) {
+  static override access_override(tags const& t, osm_obj_type const type) {
+    if (type == osm_obj_type::kNode && t.highway_ == "crossing" &&
+        t.barrier_.empty()) {
+      return override::kWhitelist;
+    }
+
     if (t.is_route_ || t.is_ferry_route_) {
       return override::kBlacklist;
     }

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -316,11 +316,14 @@ way_properties get_way_properties(
 
 std::pair<node_properties, level_bits_t> get_node_properties(tags const& t) {
   auto const [from, to, is_multi] = get_levels(t);
+  auto const ignore_bike_access =
+      t.highway_ == "crossing"sv && t.barrier_.empty();
   auto p = node_properties{};
   std::memset(&p, 0, sizeof(node_properties));
   p.from_level_ = to_idx(from);
   p.is_foot_accessible_ = is_accessible<foot_profile>(t, osm_obj_type::kNode);
-  p.is_bike_accessible_ = is_accessible<bike_profile>(t, osm_obj_type::kNode);
+  p.is_bike_accessible_ =
+      ignore_bike_access || is_accessible<bike_profile>(t, osm_obj_type::kNode);
   p.is_car_accessible_ = is_accessible<car_profile>(t, osm_obj_type::kNode);
   p.is_bus_accessible_ = is_accessible<bus_profile>(t, osm_obj_type::kNode);
   p.is_elevator_ = t.is_elevator_;

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -316,14 +316,11 @@ way_properties get_way_properties(
 
 std::pair<node_properties, level_bits_t> get_node_properties(tags const& t) {
   auto const [from, to, is_multi] = get_levels(t);
-  auto const ignore_bike_access =
-      t.highway_ == "crossing"sv && t.barrier_.empty();
   auto p = node_properties{};
   std::memset(&p, 0, sizeof(node_properties));
   p.from_level_ = to_idx(from);
   p.is_foot_accessible_ = is_accessible<foot_profile>(t, osm_obj_type::kNode);
-  p.is_bike_accessible_ =
-      ignore_bike_access || is_accessible<bike_profile>(t, osm_obj_type::kNode);
+  p.is_bike_accessible_ = is_accessible<bike_profile>(t, osm_obj_type::kNode);
   p.is_car_accessible_ = is_accessible<car_profile>(t, osm_obj_type::kNode);
   p.is_bus_accessible_ = is_accessible<bus_profile>(t, osm_obj_type::kNode);
   p.is_elevator_ = t.is_elevator_;

--- a/test/extract_test.cc
+++ b/test/extract_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <string_view>
 
 #include "cista/mmap.h"
@@ -108,6 +109,102 @@ constexpr auto const kLowEmissionZoneOsm =
     <tag k="name" v="Test LEZ"/>
   </relation>
 </osm>)osm";
+
+constexpr auto const kCrossingNodeAccessOsm =
+    R"osm(<osm version="0.6" generator="test">
+  <node id="1" lat="48.0000" lon="8.9990"/>
+  <node id="2" lat="48.0000" lon="9.0000">
+    <tag k="highway" v="crossing"/>
+    <tag k="bicycle" v="no"/>
+    <tag k="foot" v="no"/>
+    <tag k="motor_vehicle" v="no"/>
+    <tag k="bus" v="no"/>
+  </node>
+  <node id="3" lat="48.0000" lon="9.0010"/>
+  <node id="4" lat="47.9990" lon="9.0000"/>
+  <node id="5" lat="48.0010" lon="9.0000"/>
+
+  <node id="11" lat="48.0100" lon="8.9990"/>
+  <node id="12" lat="48.0100" lon="9.0000">
+    <tag k="highway" v="crossing"/>
+    <tag k="bicycle" v="no"/>
+    <tag k="barrier" v="yes"/>
+  </node>
+  <node id="13" lat="48.0100" lon="9.0010"/>
+  <node id="14" lat="48.0090" lon="9.0000"/>
+  <node id="15" lat="48.0110" lon="9.0000"/>
+
+  <node id="21" lat="48.0200" lon="8.9990"/>
+  <node id="22" lat="48.0200" lon="9.0000">
+    <tag k="highway" v="traffic_signals"/>
+    <tag k="bicycle" v="no"/>
+  </node>
+  <node id="23" lat="48.0200" lon="9.0010"/>
+  <node id="24" lat="48.0190" lon="9.0000"/>
+  <node id="25" lat="48.0210" lon="9.0000"/>
+
+  <way id="101">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="102">
+    <nd ref="4"/>
+    <nd ref="2"/>
+    <nd ref="5"/>
+    <tag k="highway" v="footway"/>
+    <tag k="bicycle" v="no"/>
+  </way>
+  <way id="111">
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="112">
+    <nd ref="14"/>
+    <nd ref="12"/>
+    <nd ref="15"/>
+    <tag k="highway" v="footway"/>
+  </way>
+  <way id="121">
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="highway" v="residential"/>
+  </way>
+  <way id="122">
+    <nd ref="24"/>
+    <nd ref="22"/>
+    <nd ref="25"/>
+    <tag k="highway" v="service"/>
+  </way>
+</osm>)osm";
+
+struct crossing_node_access_test : public ::testing::Test {
+  static void SetUpTestSuite() {
+    dir_ = fs::temp_directory_path() / "osr_crossing_node_access_test";
+    auto ec = std::error_code{};
+    fs::remove_all(dir_, ec);
+    fs::create_directories(dir_, ec);
+    extract(false,
+            osr::test::write_osm_pbf("osr_crossing_node_access",
+                                     kCrossingNodeAccessOsm)
+                .generic_string(),
+            dir_, {});
+    ways_ = std::make_unique<ways>(dir_, cista::mmap::protection::READ);
+  }
+
+  static void TearDownTestSuite() {
+    ways_.reset();
+    auto ec = std::error_code{};
+    fs::remove_all(dir_, ec);
+  }
+
+  static inline fs::path dir_{};
+  static inline std::unique_ptr<ways> ways_{};
+};
 
 }  // namespace
 
@@ -243,4 +340,38 @@ TEST(extract, marks_low_emission_zone_ways) {
   EXPECT_TRUE(w.r_->way_properties_[*inside].is_in_low_emission_zone());
   EXPECT_FALSE(w.r_->way_properties_[*outside].is_in_low_emission_zone());
   EXPECT_TRUE(w.r_->way_properties_[*crossing].is_in_low_emission_zone());
+}
+
+TEST_F(crossing_node_access_test, unbarriered_crossing_ignores_bicycle_access) {
+  auto const node = ways_->find_node_idx(osm_node_idx_t{2});
+  ASSERT_TRUE(node.has_value());
+  EXPECT_TRUE(ways_->r_->node_properties_[*node].is_bike_accessible());
+}
+
+TEST_F(crossing_node_access_test, other_profiles_are_unchanged) {
+  auto const node = ways_->find_node_idx(osm_node_idx_t{2});
+  ASSERT_TRUE(node.has_value());
+  auto const& properties = ways_->r_->node_properties_[*node];
+  EXPECT_FALSE(properties.is_walk_accessible());
+  EXPECT_FALSE(properties.is_car_accessible());
+  EXPECT_FALSE(properties.is_bus_accessible());
+}
+
+TEST_F(crossing_node_access_test, barrier_keeps_bicycle_access_restriction) {
+  auto const node = ways_->find_node_idx(osm_node_idx_t{12});
+  ASSERT_TRUE(node.has_value());
+  EXPECT_FALSE(ways_->r_->node_properties_[*node].is_bike_accessible());
+}
+
+TEST_F(crossing_node_access_test,
+       non_crossing_keeps_bicycle_access_restriction) {
+  auto const node = ways_->find_node_idx(osm_node_idx_t{22});
+  ASSERT_TRUE(node.has_value());
+  EXPECT_FALSE(ways_->r_->node_properties_[*node].is_bike_accessible());
+}
+
+TEST_F(crossing_node_access_test, way_access_is_unchanged) {
+  auto const crossing = ways_->find_way(osm_way_idx_t{102});
+  ASSERT_TRUE(crossing.has_value());
+  EXPECT_FALSE(ways_->r_->way_properties_[*crossing].is_bike_accessible());
 }


### PR DESCRIPTION
Bike routes can take large detours when a `highway=crossing` node is tagged `bicycle=no`.

At these crossings, the tag describes the crossing movement: cycling is not allowed across the pedestrian crossing, but the road itself is still open to bikes. Because the node belongs to both the crossing and the road, OSR currently applies `bicycle=no` to both and cuts the road in the bicycle graph.

This happens in Liège at [node 60293129](https://www.openstreetmap.org/node/60293129) and [node 60293135](https://www.openstreetmap.org/node/60293135). Both are tagged `highway=crossing`, `foot=designated`, and `bicycle=no`, with no `barrier`. This [Transitous route](https://api.transitous.org/api/v1/plan?fromPlace=50.6355,5.5650&toPlace=50.6366,5.5705&directModes=BIKE&timetableView=false&maxDirectTime=7200) currently returns a 3,625 m / 900 s detour.

Using the same Belgium PBF for both local OSR graphs:

- master (`5b0f1bfa`): 3,646 m / 905 s
- with this change: 1,342 m / 367 s

This change ignores node-level bike access restrictions at `highway=crossing` nodes without a `barrier`. Way access is still checked, so a crossing way that does not allow bikes remains unavailable. Crossings with a barrier and non-crossing access nodes keep their current behavior. Foot, car, and bus routing are unchanged.

[OSRM](https://github.com/Project-OSRM/osrm-backend/blob/e9436d3293f5888da48e96de54a3d8b483cc0b88/profiles/bicycle.lua#L235-L258) and [Valhalla](https://github.com/valhalla/valhalla/blob/9eaaf5d3a86cc32f99615d66728b83c3e129ccd7/lua/graph.lua#L2130-L2133) also special-case bicycle access restrictions on `highway=crossing` nodes.

Tests cover the fixed case and verify that barriers, non-crossing nodes, way access, and the other profiles keep their current behavior.