### PR TITLE
Fix additional edge count check

### DIFF
--- a/include/osr/routing/sharing_data.h
+++ b/include/osr/routing/sharing_data.h
@@ -13,11 +13,15 @@
 namespace osr {
 
 inline void verify_additional_edge_count(
-    hash_map<node_idx_t, std::vector<additional_edge>> const& edges) {
+    hash_map<node_idx_t, std::vector<additional_edge>> const& edges,
+    node_idx_t::value_t const additional_node_offset) {
   for (auto const& [node, node_edges] : edges) {
+    if (to_idx(node) < additional_node_offset) {
+      continue;
+    }
     utl::verify(node_edges.size() <= kMaxWaysPerNode,
-                "node {} has {} additional edges, maximum is {}", node,
-                node_edges.size(), kMaxWaysPerNode);
+                "additional node {} has {} additional edges, maximum is {}",
+                node, node_edges.size(), kMaxWaysPerNode);
   }
 }
 

--- a/src/map_matching.cc
+++ b/src/map_matching.cc
@@ -362,7 +362,7 @@ matched_route map_match(
       return min_start_cost;
     };
 
-    verify_additional_edge_count(seg.additional_edges_);
+    verify_additional_edge_count(seg.additional_edges_, additional_node_offset);
     seg.sharing_ = std::make_unique<sharing_data>(sharing_data{
         .additional_node_offset_ = additional_node_offset,
         .additional_node_coordinates_ = additional_node_coordinates,

--- a/test/sharing_routing_test.cc
+++ b/test/sharing_routing_test.cc
@@ -68,7 +68,7 @@ struct test_sharing_data {
   }
 
   sharing_data view(ways const& w) const {
-    verify_additional_edge_count(additional_edges_);
+    verify_additional_edge_count(additional_edges_, w.n_nodes());
     return {.start_allowed_ = &start_allowed_,
             .end_allowed_ = &end_allowed_,
             .through_allowed_ = &through_allowed_,


### PR DESCRIPTION
Fix for the `verify_additional_edge_count` check from #135:
This check is only necessary at additional nodes.
Limiting the number of additional edges at graph nodes could cause the verify to fail in some GBFS cases.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>